### PR TITLE
add travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: go
+
+go:
+  - 1.x
+
+install:
+  - go get -u golang.org/x/lint/golint
+  - go get -u golang.org/x/crypto/blake2b
+
+script:
+  - test -z "`gofmt -l .`"
+  - test -z "`golint ./utreexo/...`"
+  - go test -v ./utreexo/...


### PR DESCRIPTION
Add a travis config file.
Go version is 1 series.
The checks are 'gofmt', 'golint' and 'go test'.
'gofmt' and 'go test' are only in the `utreexo` folder.

It does not work only by merging this config file.
You need to register for 'travis ci'.

You can include 'go vet' and other checks, but only basic ones.
If you also need to check the 'cmd' folder you will need to change it.