### PR TITLE
Fix minor error in sim.go

### DIFF
--- a/cmd/simcmd/sim.go
+++ b/cmd/simcmd/sim.go
@@ -41,7 +41,7 @@ var schedFileName = optionCmd.String("schedFileName", "schedule1pos.clr", "assig
 
 func main() {
 	//check if enough arguments were given
-	if len(os.Args) < 3{
+	if len(os.Args) < 2 {
 		fmt.Println(msg)
 		os.Exit(1)
 	}
@@ -53,7 +53,7 @@ func main() {
 		fmt.Println("Generating txo time to live...")
 		txottl.ReadTTLdb()
 	case "ibdsim":
-		optionCmd.Parse(os.Args[2:3])
+		optionCmd.Parse(os.Args[2:])
 		err := ibdsim.RunIBD(*ttlfn, *schedFileName)
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
Fixes the problem with program not running unless you give it 3 arguments. Also fixes the [2:3] array issue.

Sorry for the simple dumb mistake. This fixes them.