### PR TITLE
Added goroutines for reading blocks off the .dat files

### DIFF
--- a/cmd/ibdsim/ttldb.go
+++ b/cmd/ibdsim/ttldb.go
@@ -2,7 +2,6 @@ package ibdsim
 
 import (
 	"fmt"
-	"os"
 	"sync"
 
 	"github.com/mit-dci/lit/wire"
@@ -11,7 +10,7 @@ import (
 )
 
 //writeBlock sends off ttl info to dbWorker to be written to ttldb
-func writeBlock(tx []*wire.MsgTx, tipnum int, tipFile *os.File,
+func writeBlock(tx []*wire.MsgTx, tipnum int,
 	batchan chan *leveldb.Batch, wg *sync.WaitGroup) error {
 
 	blockBatch := new(leveldb.Batch)
@@ -34,12 +33,6 @@ func writeBlock(tx []*wire.MsgTx, tipnum int, tipFile *os.File,
 
 	//sent to dbworker to be written to ttldb asynchronously
 	batchan <- blockBatch
-
-	//write to the .txos file
-	_, err := tipFile.WriteAt(simutil.U32tB(uint32(tipnum)), 0)
-	if err != nil {
-		panic(err)
-	}
 
 	return nil
 }

--- a/cmd/utils/types.go
+++ b/cmd/utils/types.go
@@ -2,6 +2,8 @@ package simutil
 
 import (
 	"crypto/sha256"
+
+	"github.com/mit-dci/lit/wire"
 )
 
 type Hash [32]byte
@@ -48,4 +50,9 @@ type RawHeaderData struct {
 	Prevhash          [32]byte
 	FileNum           [4]byte
 	Offset            [4]byte
+}
+
+type BlockToWrite struct {
+	Txs    []*wire.MsgTx
+	Height int
 }


### PR DESCRIPTION
Goroutine added for ReadRawBlockFromFile() with Blockreader() inside utils.go

Benchmark shows around 12% improvement when run 
```./simcmd genproofs -testnet=1 && ./simcmd ibdsim -testnet=1```

compared to the old way.