### PR TITLE
Add paths for the files.

### DIFF
--- a/cmd/ibdsim/ibdsim.go
+++ b/cmd/ibdsim/ibdsim.go
@@ -43,12 +43,12 @@ func RunIBD(isTestnet bool, offsetfile string, ttldb string, sig chan bool) erro
 	}
 	defer lvdb.Close()
 
-	pFile, err := os.OpenFile("proof.dat", os.O_RDONLY, 0400)
+	pFile, err := os.OpenFile(simutil.PFilePath, os.O_RDONLY, 0400)
 	if err != nil {
 		return err
 	}
 
-	pOffsetFile, err := os.OpenFile("proofoffset.dat", os.O_RDONLY, 0400)
+	pOffsetFile, err := os.OpenFile(simutil.POffsetFilePath, os.O_RDONLY, 0400)
 	if err != nil {
 		return err
 	}
@@ -57,7 +57,7 @@ func RunIBD(isTestnet bool, offsetfile string, ttldb string, sig chan bool) erro
 	//grab the last block height from currentoffsetheight
 	//currentoffsetheight saves the last height from the offsetfile
 	var currentOffsetHeightByte [4]byte
-	currentOffsetHeightFile, err := os.Open("currentoffsetheight")
+	currentOffsetHeightFile, err := os.Open(simutil.CurrentOffsetFilePath)
 	if err != nil {
 		panic(err)
 	}
@@ -86,7 +86,7 @@ func RunIBD(isTestnet bool, offsetfile string, ttldb string, sig chan bool) erro
 	bchan := make(chan simutil.BlockToWrite, 10)
 
 	// Reads block asynchronously from .dat files
-	go simutil.BlockReader(bchan, currentOffsetHeight, height, offsetfile)
+	go simutil.BlockReader(bchan, currentOffsetHeight, height, simutil.OffsetFilePath)
 
 	for ; height != currentOffsetHeight && stop != true; height++ {
 

--- a/cmd/ibdsim/offsetfile.go
+++ b/cmd/ibdsim/offsetfile.go
@@ -11,8 +11,9 @@ import (
 //Builds the offset file
 func buildOffsetFile(
 	tip simutil.Hash, tipnum int, nextMap map[[32]byte]simutil.RawHeaderData,
-	offsetfile string, offsetfinished chan bool) (int, error) {
-	offsetFile, err := os.OpenFile(offsetfile, os.O_CREATE|os.O_WRONLY, 0600)
+	offsetFilePath string, currentOffsetHeightFilePath string,
+	offsetfinished chan bool) (int, error) {
+	offsetFile, err := os.OpenFile(offsetFilePath, os.O_CREATE|os.O_WRONLY, 0600)
 	if err != nil {
 		panic(err)
 	}
@@ -38,9 +39,9 @@ func buildOffsetFile(
 			panic(err)
 		}
 	}
-	//write the last height of the offsetfile
+	// write the last height of the offsetfile
 	currentOffsetHeightFile, err := os.OpenFile(
-		"currentoffsetheight", os.O_CREATE|os.O_WRONLY, 0600)
+		currentOffsetHeightFilePath, os.O_CREATE|os.O_WRONLY, 0600)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/utils/paths.go
+++ b/cmd/utils/paths.go
@@ -1,0 +1,32 @@
+package simutil
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// Directory paths
+var OffsetDirPath string = filepath.Join(".", "offsetdata")
+var ProofDirPath string = filepath.Join(".", "proofdata")
+var ForestDirPath string = filepath.Join(".", "forestdata")
+
+// File paths
+
+// offsetdata file paths
+var OffsetFilePath string = filepath.Join(OffsetDirPath, "offsetfile")
+var CurrentOffsetFilePath string = filepath.Join(OffsetDirPath, "currentoffsetfile")
+var HeightFilePath string = filepath.Join(OffsetDirPath, "heightfile")
+
+// proofdata file paths
+var PFilePath string = filepath.Join(ProofDirPath, "proof.dat")
+var POffsetFilePath string = filepath.Join(ProofDirPath, "proofoffset.dat")
+
+// forestdata file paths
+var ForestFilePath string = filepath.Join(ForestDirPath, "forestfile.dat")
+var MiscForestFilePath string = filepath.Join(ForestDirPath, "miscforestfile.dat")
+
+func MakePaths() {
+	os.MkdirAll(OffsetDirPath, os.ModePerm)
+	os.MkdirAll(ProofDirPath, os.ModePerm)
+	os.MkdirAll(ForestDirPath, os.ModePerm)
+}


### PR DESCRIPTION
Structed the files. 3 directories for the files are now created.
offsetdata/,  proofdata/, and forestdata/ are now created and all
relevant files are stored in each of the directories.

Helps with organization.