### PR TITLE
Disk resume and remove opening files in Lib

### DIFF
--- a/cmd/ibdsim/ibdsim.go
+++ b/cmd/ibdsim/ibdsim.go
@@ -43,12 +43,12 @@ func RunIBD(isTestnet bool, offsetfile string, ttldb string, sig chan bool) erro
 	}
 	defer lvdb.Close()
 
-	pFile, err := os.OpenFile("proof.dat", os.O_RDONLY, 0400)
+	pFile, err := os.OpenFile(simutil.PFilePath, os.O_RDONLY, 0400)
 	if err != nil {
 		return err
 	}
 
-	pOffsetFile, err := os.OpenFile("proofoffset.dat", os.O_RDONLY, 0400)
+	pOffsetFile, err := os.OpenFile(simutil.POffsetFilePath, os.O_RDONLY, 0400)
 	if err != nil {
 		return err
 	}
@@ -57,7 +57,7 @@ func RunIBD(isTestnet bool, offsetfile string, ttldb string, sig chan bool) erro
 	//grab the last block height from currentoffsetheight
 	//currentoffsetheight saves the last height from the offsetfile
 	var currentOffsetHeightByte [4]byte
-	currentOffsetHeightFile, err := os.Open("currentoffsetheight")
+	currentOffsetHeightFile, err := os.Open(simutil.CurrentOffsetFilePath)
 	if err != nil {
 		panic(err)
 	}
@@ -86,7 +86,7 @@ func RunIBD(isTestnet bool, offsetfile string, ttldb string, sig chan bool) erro
 	bchan := make(chan simutil.BlockToWrite, 10)
 
 	// Reads block asynchronously from .dat files
-	go simutil.BlockReader(bchan, currentOffsetHeight, height, offsetfile)
+	go simutil.BlockReader(bchan, currentOffsetHeight, height, simutil.OffsetFilePath)
 
 	for ; height != currentOffsetHeight && stop != true; height++ {
 

--- a/cmd/ibdsim/offsetfile.go
+++ b/cmd/ibdsim/offsetfile.go
@@ -9,10 +9,10 @@ import (
 )
 
 //Builds the offset file
-func buildOffsetFile(
-	tip simutil.Hash, tipnum int, nextMap map[[32]byte]simutil.RawHeaderData,
-	offsetfile string, offsetfinished chan bool) (int, error) {
-	offsetFile, err := os.OpenFile(offsetfile, os.O_CREATE|os.O_WRONLY, 0600)
+func buildOffsetFile(tip simutil.Hash, tipnum int,
+	nextMap map[[32]byte]simutil.RawHeaderData, offsetFilePath string,
+	currentOffsetHeightFilePath string, offsetfinished chan bool) (int, error) {
+	offsetFile, err := os.OpenFile(offsetFilePath, os.O_CREATE|os.O_WRONLY, 0600)
 	if err != nil {
 		panic(err)
 	}
@@ -38,9 +38,9 @@ func buildOffsetFile(
 			panic(err)
 		}
 	}
-	//write the last height of the offsetfile
+	// write the last height of the offsetfile
 	currentOffsetHeightFile, err := os.OpenFile(
-		"currentoffsetheight", os.O_CREATE|os.O_WRONLY, 0600)
+		currentOffsetHeightFilePath, os.O_CREATE|os.O_WRONLY, 0600)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/utils/paths.go
+++ b/cmd/utils/paths.go
@@ -1,0 +1,32 @@
+package simutil
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// Directory paths
+var OffsetDirPath string = filepath.Join(".", "offsetdata")
+var ProofDirPath string = filepath.Join(".", "proofdata")
+var ForestDirPath string = filepath.Join(".", "forestdata")
+
+// File paths
+
+// offsetdata file paths
+var OffsetFilePath string = filepath.Join(OffsetDirPath, "offsetfile")
+var CurrentOffsetFilePath string = filepath.Join(OffsetDirPath, "currentoffsetfile")
+var HeightFilePath string = filepath.Join(OffsetDirPath, "heightfile")
+
+// proofdata file paths
+var PFilePath string = filepath.Join(ProofDirPath, "proof.dat")
+var POffsetFilePath string = filepath.Join(ProofDirPath, "proofoffset.dat")
+
+// forestdata file paths
+var ForestFilePath string = filepath.Join(ForestDirPath, "forestfile.dat")
+var MiscForestFilePath string = filepath.Join(ForestDirPath, "miscforestfile.dat")
+
+func MakePaths() {
+	os.MkdirAll(OffsetDirPath, os.ModePerm)
+	os.MkdirAll(ProofDirPath, os.ModePerm)
+	os.MkdirAll(ForestDirPath, os.ModePerm)
+}

--- a/utreexo/pollard.go
+++ b/utreexo/pollard.go
@@ -2,6 +2,7 @@ package utreexo
 
 import (
 	"fmt"
+	"os"
 	"sync"
 )
 
@@ -12,6 +13,7 @@ func (p *Pollard) Modify(adds []LeafTXO, dels []uint64) error {
 		return err
 	}
 	// fmt.Printf("pol pre add %s", p.toString())
+
 	err = p.add(adds)
 	if err != nil {
 		return err
@@ -391,9 +393,10 @@ func (p *Pollard) descendToPos(pos uint64) ([]*polNode, []*polNode, error) {
 // toFull takes a pollard and converts to a forest.
 // For debugging and seeing what pollard is doing since there's already
 // a good toString method for  forest.
-func (p *Pollard) toFull() (*Forest, error) {
+//func (p *Pollard) toFull() (*Forest, error) {
+func (p *Pollard) toFull(forestFile *os.File) (*Forest, error) {
 
-	ff := NewForest()
+	ff := NewForest(forestFile)
 	ff.height = p.height()
 	ff.numLeaves = p.numLeaves
 	ff.data = new(ramForestData)
@@ -421,8 +424,9 @@ func (p *Pollard) toFull() (*Forest, error) {
 	return ff, nil
 }
 
-func (p *Pollard) ToString() string {
-	f, err := p.toFull()
+//func (p *Pollard) ToString() string {
+func (p *Pollard) ToString(forestFile *os.File) string {
+	f, err := p.toFull(forestFile)
 	if err != nil {
 		return err.Error()
 	}

--- a/utreexo/utils.go
+++ b/utreexo/utils.go
@@ -575,3 +575,22 @@ func U64tB(i uint64) []byte {
 	binary.Write(&buf, binary.BigEndian, i)
 	return buf.Bytes()
 }
+
+// BtU8 : 1 byte to uint8.  returns ffff. if it doesn't work.
+func BtU8(b []byte) uint8 {
+	if len(b) != 1 {
+		fmt.Printf("Got %x to BtU8 (%d bytes)\n", b, len(b))
+		return 0xff
+	}
+	var i uint8
+	buf := bytes.NewBuffer(b)
+	binary.Read(buf, binary.BigEndian, &i)
+	return i
+}
+
+// U8tB : uint8 to a byte.  Always works.
+func U8tB(i uint8) []byte {
+	var buf bytes.Buffer
+	binary.Write(&buf, binary.BigEndian, i)
+	return buf.Bytes()
+}


### PR DESCRIPTION
Added functions to resume forest when using disk.
Cleaned forestdata.go and forest.go functions so they don't open up
files. Moved all the file opening functions to cmd/

So this works but is *painfully* slow.