### PR TITLE
cmd/ibdsim: Fixed errors preventing from resuming genproofs

### DIFF
--- a/cmd/ibdsim/client.go
+++ b/cmd/ibdsim/client.go
@@ -119,6 +119,9 @@ func IBDClient(isTestnet bool, offsetfile string, ttldb string, sig chan bool) e
 		}
 	}
 
+	fmt.Printf("Block %d add %d del %d %s plus %.2f total %.2f \n",
+		height, totalTXOAdded, totalDels, p.Stats(),
+		plustime.Seconds(), time.Now().Sub(starttime).Seconds())
 	fmt.Println("Done Writing")
 
 	done <- true

--- a/cmd/ibdsim/offsetfile.go
+++ b/cmd/ibdsim/offsetfile.go
@@ -103,6 +103,9 @@ func readRawHeadersFromFile(fileNum uint32) ([]simutil.RawHeaderData, error) {
 
 		//offset for the next block from the current position
 		loc, err = f.Seek(int64(simutil.LBtU32(size[:]))-80, 1)
+		if err != nil {
+			return nil, err
+		}
 		blockHeaders = append(blockHeaders, *b)
 		b = nil
 	}

--- a/cmd/ibdsim/server.go
+++ b/cmd/ibdsim/server.go
@@ -116,7 +116,7 @@ func getProof(height uint32, pFile *os.File, pOffsetFile *os.File) ([]byte, erro
 	pOffsetFile.Seek(int64(height*4), 0)
 	pOffsetFile.Read(offset[:])
 	if offset == [4]byte{} && height != uint32(0) {
-		panic(fmt.Errorf("offset returned nil"))
+		panic(fmt.Errorf("offset returned nil\nIt's likely that genproofs was exited before finishing\nRun genproofs again and that will probably fix the problem"))
 	}
 
 	pFile.Seek(int64(simutil.BtU32(offset[:])), 0)
@@ -128,7 +128,7 @@ func getProof(height uint32, pFile *os.File, pOffsetFile *os.File) ([]byte, erro
 	copy(compare0[:], heightbytes[:])
 
 	var compare1 [4]byte
-	copy(compare1[:], utreexo.U32tB(height))
+	copy(compare1[:], utreexo.U32tB(height+1))
 	//check if height matches
 	if compare0 != compare1 {
 		fmt.Println("read:, given:", compare0, compare1)

--- a/cmd/simutil/paths.go
+++ b/cmd/simutil/paths.go
@@ -20,6 +20,7 @@ var HeightFilePath string = filepath.Join(OffsetDirPath, "heightfile")
 // proofdata file paths
 var PFilePath string = filepath.Join(ProofDirPath, "proof.dat")
 var POffsetFilePath string = filepath.Join(ProofDirPath, "proofoffset.dat")
+var POffsetCurrentOffsetFilePath string = filepath.Join(ProofDirPath, "lastproofoffset.dat")
 
 // forestdata file paths
 var ForestFilePath string = filepath.Join(ForestDirPath, "forestfile.dat")

--- a/cmd/simutil/utils.go
+++ b/cmd/simutil/utils.go
@@ -248,3 +248,12 @@ func GetTipNum(txos string) (int, error) {
 	f.Close()
 	return num, nil
 }
+
+func GetPOffsetNum(pOffsetCurrentIndexFile *os.File) (uint32, error) {
+	var pOffsetByte [4]byte
+	_, err := pOffsetCurrentIndexFile.ReadAt(pOffsetByte[:], 0)
+	if err != nil {
+		return 0, err
+	}
+	return BtU32(pOffsetByte[:]), nil
+}

--- a/utreexo/forest.go
+++ b/utreexo/forest.go
@@ -428,6 +428,7 @@ func (f *Forest) PosMapSanity() error {
 // miscForestFile is where numLeaves and height is stored
 func (f *Forest) RestoreForest(miscForestFile *os.File, forestFile *os.File) error {
 
+	fmt.Println("Restoring Forest...")
 	// This restores the numLeaves
 	var byteLeaves [8]byte
 	_, err := miscForestFile.Read(byteLeaves[:])
@@ -439,23 +440,16 @@ func (f *Forest) RestoreForest(miscForestFile *os.File, forestFile *os.File) err
 
 	// This restores the positionMap
 	var i uint64
+	fmt.Printf("%d iterations to do\n", f.numLeaves)
 	for i = uint64(0); i < f.numLeaves; i++ {
 		f.positionMap[f.data.read(i).Mini()] = i
+
+		if i%uint64(10000) == 0 && i != uint64(0) {
+			fmt.Printf("Done %d iterations\n", i)
+		}
 	}
 	if f.positionMap == nil {
 		return fmt.Errorf("Generated positionMap is nil")
-	}
-	var s string
-	for m, pos := range f.positionMap {
-		s += fmt.Sprintf("pos %d, leaf %x\n", pos, m)
-	}
-	lol, err := os.OpenFile("generatedpositionmap", os.O_CREATE|os.O_WRONLY, 0600)
-	if err != nil {
-		panic(err)
-	}
-	_, err = lol.WriteString(s)
-	if err != nil {
-		panic(err)
 	}
 
 	// This restores the height
@@ -466,6 +460,7 @@ func (f *Forest) RestoreForest(miscForestFile *os.File, forestFile *os.File) err
 	}
 	f.height = BtU8(byteHeight[:])
 	fmt.Println("Forest height:", f.height)
+	fmt.Println("Done restoring forest")
 
 	return nil
 }

--- a/utreexo/pollardutil.go
+++ b/utreexo/pollardutil.go
@@ -16,7 +16,7 @@ type Pollard struct {
 	tops []polNode // slice of the tree tops, which are polNodes.
 	// tops are in big to small order
 	// BUT THEY'RE WEIRD!  The left / right children are actual children,
-	// not neices as they are in every lower level.
+	// not nieces as they are in every lower level.
 
 	hashesEver, rememberEver, overWire uint64
 


### PR DESCRIPTION
Fixes a off-by-one bug and saves and restores the current offset
of pOffsetFile. Also removes some fmt.Sprintf()s that were massively
slowing the stop and resume.