### PR TITLE
add swapRange to forest data and removev4

### DIFF
--- a/utreexo/pollard.go
+++ b/utreexo/pollard.go
@@ -160,7 +160,7 @@ func (p *Pollard) rem2(dels []uint64) error {
 				len(hashDirt) != 0 && hashDirt[0] > swaprows[h][0].to {
 				// re-descending here which isn't great
 				// fmt.Printf("hashing from dirt %d\n", hashDirt[0])
-				hn, err = p.HnFromPos(hashDirt[0])
+				hn, err = p.hnFromPos(hashDirt[0])
 				if err != nil {
 					return err
 				}
@@ -244,7 +244,7 @@ func (p *Pollard) rem2(dels []uint64) error {
 	return nil
 }
 
-func (p *Pollard) HnFromPos(pos uint64) (*hashableNode, error) {
+func (p *Pollard) hnFromPos(pos uint64) (*hashableNode, error) {
 	if !inForest(pos, p.numLeaves, p.height()) {
 		// fmt.Printf("HnFromPos %d out of forest\n", pos)
 		return nil, nil

--- a/utreexo/pollard_test.go
+++ b/utreexo/pollard_test.go
@@ -12,7 +12,7 @@ func TestPollardRand(t *testing.T) {
 		// z := 16
 		rand.Seed(int64(z))
 		fmt.Printf("randseed %d\n", z)
-		err := pollardRandomRemember(2000)
+		err := pollardRandomRemember(5)
 		if err != nil {
 			fmt.Printf("randseed %d\n", z)
 			t.Fatal(err)


### PR DESCRIPTION
this stops use of floorTransform for forest Modify (still used in Undo, but can get rid of that later) and uses swapRange to move linear runs of hashes at once, hopefully speeding things up.