### PR TITLE
utreexo/forest.go: Changes to RestoreForest()

### DIFF
--- a/cmd/ibdsim/genproofs.go
+++ b/cmd/ibdsim/genproofs.go
@@ -172,9 +172,8 @@ func BuildProofs(
 			return err
 		}
 
-		newForest = utreexo.NewForest(forestFile)
 		// Restores all the forest data
-		err = newForest.RestoreForest(miscForestFile, forestFile)
+		newForest, err = utreexo.RestoreForest(miscForestFile, forestFile)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
Changes RestoreForest() from a method to a function
No longer relies on calling newForest() in cmd/

Addresses the comment by @adiabat on #68 