### PR TITLE
Fix auntable() comment

### DIFF
--- a/utreexo/pollardutil.go
+++ b/utreexo/pollardutil.go
@@ -35,7 +35,7 @@ func (n *polNode) auntOp() Hash {
 	return Parent(n.niece[0].data, n.niece[1].data)
 }
 
-// auntOp tells you if you can call auntOp on a node
+// auntable tells you if you can call auntOp on a node
 func (n *polNode) auntable() bool {
 	return n.niece[0] != nil && n.niece[1] != nil
 }


### PR DESCRIPTION
So there is a pretty big typo where you call the function auntable() as auntOp. Not sure if you like to have a bunch of commits for one line changes so this could be fixed in the next big(er) thing too.