### PR TITLE
Allow Pollard to generate proofs

### DIFF
--- a/utreexo/pollardfull_test.go
+++ b/utreexo/pollardfull_test.go
@@ -27,7 +27,7 @@ func pollardFullRandomRemember(blocks int32) error {
 	// }
 
 	var fp, p Pollard
-	fp.positionMap = make(map[MiniHash]uint64) // map now non-nil
+	fp = NewFullPollard()
 
 	// p.Minleaves = 0
 

--- a/utreexo/pollardfull_test.go
+++ b/utreexo/pollardfull_test.go
@@ -7,17 +7,16 @@ import (
 )
 
 func TestPollardFullRand(t *testing.T) {
-	for z := 0; z < 30; z++ {
-		// z := 11221
-		// z := 55
-		rand.Seed(int64(z))
+	// for z := 0; z < 30; z++ {
+	z := 1
+	rand.Seed(int64(z))
+	fmt.Printf("randseed %d\n", z)
+	err := pollardFullRandomRemember(5)
+	if err != nil {
 		fmt.Printf("randseed %d\n", z)
-		err := pollardFullRandomRemember(60)
-		if err != nil {
-			fmt.Printf("randseed %d\n", z)
-			t.Fatal(err)
-		}
+		t.Fatal(err)
 	}
+	// }
 }
 
 func pollardFullRandomRemember(blocks int32) error {
@@ -35,7 +34,7 @@ func pollardFullRandomRemember(blocks int32) error {
 	sn := NewSimChain(0x07)
 	sn.lookahead = 400
 	for b := int32(0); b < blocks; b++ {
-		adds, delHashes := sn.NextBlock(rand.Uint32() & 0xff)
+		adds, delHashes := sn.NextBlock(rand.Uint32() & 0x03)
 
 		fmt.Printf("\t\t\tstart block %d del %d add %d - %s\n",
 			sn.blockHeight, len(delHashes), len(adds), p.Stats())
@@ -78,21 +77,21 @@ func pollardFullRandomRemember(blocks int32) error {
 
 		fmt.Printf("pol postadd %s", p.ToString())
 
-		fmt.Printf("frs postadd %s", fp.ToString())
+		fmt.Printf("fulpol postadd %s", fp.ToString())
 
 		fullTops := fp.topHashesReverse()
 		polTops := p.topHashesReverse()
 
 		// check that tops match
 		if len(fullTops) != len(polTops) {
-			return fmt.Errorf("block %d full %d tops, pol %d tops",
+			return fmt.Errorf("block %d fulpol %d tops, pol %d tops",
 				sn.blockHeight, len(fullTops), len(polTops))
 		}
 		fmt.Printf("top matching: ")
 		for i, ft := range fullTops {
-			fmt.Printf("f %04x p %04x ", ft[:4], polTops[i][:4])
+			fmt.Printf("fp %04x p %04x ", ft[:4], polTops[i][:4])
 			if ft != polTops[i] {
-				return fmt.Errorf("block %d top %d mismatch, full %x pol %x",
+				return fmt.Errorf("block %d top %d mismatch, fulpol %x pol %x",
 					sn.blockHeight, i, ft[:4], polTops[i][:4])
 			}
 		}

--- a/utreexo/pollardfull_test.go
+++ b/utreexo/pollardfull_test.go
@@ -7,16 +7,16 @@ import (
 )
 
 func TestPollardFullRand(t *testing.T) {
-	// for z := 0; z < 30; z++ {
-	z := 1
-	rand.Seed(int64(z))
-	fmt.Printf("randseed %d\n", z)
-	err := pollardFullRandomRemember(5)
-	if err != nil {
+	for z := 0; z < 30; z++ {
+		// z := 1
+		rand.Seed(int64(z))
 		fmt.Printf("randseed %d\n", z)
-		t.Fatal(err)
+		err := pollardFullRandomRemember(50)
+		if err != nil {
+			fmt.Printf("randseed %d\n", z)
+			t.Fatal(err)
+		}
 	}
-	// }
 }
 
 func pollardFullRandomRemember(blocks int32) error {

--- a/utreexo/pollardutil.go
+++ b/utreexo/pollardutil.go
@@ -27,6 +27,8 @@ type Pollard struct {
 
 	//	Lookahead int32  // remember leafs below this TTL
 	//	Minleaves uint64 // remember everything below this leaf count
+
+	positionMap map[Hash]uint64
 }
 
 // PolNode is a node in the pollard forest

--- a/utreexo/pollardutil.go
+++ b/utreexo/pollardutil.go
@@ -28,7 +28,7 @@ type Pollard struct {
 	//	Lookahead int32  // remember leafs below this TTL
 	//	Minleaves uint64 // remember everything below this leaf count
 
-	positionMap map[Hash]uint64
+	positionMap map[MiniHash]uint64
 }
 
 // PolNode is a node in the pollard forest

--- a/utreexo/pollarfull.go
+++ b/utreexo/pollarfull.go
@@ -17,6 +17,13 @@ func (p *Pollard) read(pos uint64) Hash {
 	return n.data
 }
 
+// NewFullPollard gives you a Pollard with an activated
+func NewFullPollard() Pollard {
+	var p Pollard
+	p.positionMap = make(map[MiniHash]uint64)
+	return p
+}
+
 // VerifyBlockProof :
 func (p *Pollard) VerifyBlockProof(bp BlockProof) bool {
 	ok, _ := VerifyBlockProof(bp, p.topHashesReverse(), p.numLeaves, p.height())

--- a/utreexo/pollarfull.go
+++ b/utreexo/pollarfull.go
@@ -14,6 +14,12 @@ func (p *Pollard) read(pos uint64) Hash {
 	return n.data
 }
 
+// VerifyBlockProof :
+func (p *Pollard) VerifyBlockProof(bp BlockProof) bool {
+	ok, _ := VerifyBlockProof(bp, p.topHashesReverse(), p.numLeaves, p.height())
+	return ok
+}
+
 // TODO make interface to reduce code dupe
 
 // ProveBlock, but for pollard.

--- a/utreexo/pollarfull.go
+++ b/utreexo/pollarfull.go
@@ -11,6 +11,9 @@ func (p *Pollard) read(pos uint64) Hash {
 		fmt.Printf("read err %s pos %d\n", err.Error(), pos)
 		return empty
 	}
+	if n == nil {
+		return empty
+	}
 	return n.data
 }
 
@@ -18,6 +21,17 @@ func (p *Pollard) read(pos uint64) Hash {
 func (p *Pollard) VerifyBlockProof(bp BlockProof) bool {
 	ok, _ := VerifyBlockProof(bp, p.topHashesReverse(), p.numLeaves, p.height())
 	return ok
+}
+
+// PosMapSanity is costly / slow: check that everything in posMap is correct
+func (p *Pollard) PosMapSanity() error {
+	for i := uint64(0); i < p.numLeaves; i++ {
+		if p.positionMap[p.read(i).Mini()] != i {
+			return fmt.Errorf("positionMap error: map says %x @%d but it's @%d",
+				p.read(i).Prefix(), p.positionMap[p.read(i).Mini()], i)
+		}
+	}
+	return nil
 }
 
 // TODO make interface to reduce code dupe

--- a/utreexo/pollarfull.go
+++ b/utreexo/pollarfull.go
@@ -1,0 +1,150 @@
+package utreexo
+
+import (
+	"fmt"
+)
+
+// read is just like forestData read but for pollard
+func (p *Pollard) read(pos uint64) Hash {
+	n, _, _, err := p.grabPos(pos)
+	if err != nil {
+		fmt.Printf("read err %s pos %d\n", err.Error(), pos)
+		return empty
+	}
+	return n.data
+}
+
+// TODO make interface to reduce code dupe
+
+// ProveBlock, but for pollard.
+// Now getting really obvious that forest and pollard should both satisfy some
+// kind of utreexoy interface.  And maybe forest shouldn't be called forest.
+// Anyway do that after this.
+func (p *Pollard) ProveBlock(hs []Hash) (BlockProof, error) {
+	var bp BlockProof
+	// skip everything if empty (should this be an error?
+	if len(hs) == 0 {
+		return bp, nil
+	}
+	if p.numLeaves < 2 {
+		return bp, nil
+	}
+
+	// for h, p := range f.positionMap {
+	// 	fmt.Printf("%x@%d ", h[:4], p)
+	// }
+
+	// first get all the leaf positions
+	// there shouldn't be any duplicates in hs, but if there are I guess
+	// it's not an error.
+	bp.Targets = make([]uint64, len(hs))
+
+	for i, wanted := range hs {
+
+		pos, ok := p.positionMap[wanted.Mini()]
+		if !ok {
+			fmt.Printf(p.ToString())
+			return bp, fmt.Errorf("hash %x not found", wanted)
+		}
+
+		// should never happen
+		if pos > p.numLeaves {
+			for m, p := range p.positionMap {
+				fmt.Printf("%x @%d\t", m[:4], p)
+			}
+			return bp, fmt.Errorf(
+				"ProveBlock: got leaf position %d but only %d leaves exist",
+				pos, p.numLeaves)
+		}
+		bp.Targets[i] = pos
+	}
+	// targets need to be sorted because the proof hashes are sorted
+	// NOTE that this is a big deal -- we lose in-block positional information
+	// because of this sorting.  Does that hurt locality or performance?  My
+	// guess is no, but that's untested.
+	sortUint64s(bp.Targets)
+
+	// TODO feels like you could do all this with just slices and no maps...
+	// that would be better
+	// proofTree is the partially populated tree of everything needed for the
+	// proofs
+	proofTree := make(map[uint64]Hash)
+
+	// go through each target and add a proof for it up to the intersection
+	for _, pos := range bp.Targets {
+		// add hash for the deletion itself and its sibling
+		// if they already exist, skip the whole thing
+		_, alreadyThere := proofTree[pos]
+		if alreadyThere {
+			//			fmt.Printf("%d omit already there\n", pos)
+			continue
+		}
+		// TODO change this for the real thing; no need to prove 0-tree root.
+		// but we still need to verify it and tag it as a target.
+		if pos == p.numLeaves-1 && pos&1 == 0 {
+			proofTree[pos] = p.read(pos)
+			// fmt.Printf("%d add as root\n", pos)
+			continue
+		}
+
+		// always put in both siblings when on the bottom row
+		// this can be out of order but it will be sorted later
+		proofTree[pos] = p.read(pos)
+		proofTree[pos^1] = p.read(pos ^ 1)
+		// fmt.Printf("added leaves %d, %d\n", pos, pos^1)
+
+		treeTop := detectSubTreeHeight(pos, p.numLeaves, p.height())
+		pos = up1(pos, p.height())
+		// go bottom to top and add siblings into the partial tree
+		// start at height 1 though; we always populate the bottom leaf and sibling
+		// This either gets to the top, or intersects before that and deletes
+		// something
+		for h := uint8(1); h < treeTop; h++ {
+			// check if the sibling is already there, in which case we're done
+			// also check if the parent itself is there, in which case we delete it!
+			// I think this with the early ignore at the bottom make it optimal
+			_, selfThere := proofTree[pos]
+			_, sibThere := proofTree[pos^1]
+			if sibThere {
+				// sibling position already exists in partial tree; done
+				// with this branch
+
+				// TODO seems that this never happens and can be removed
+				panic("this never happens...?")
+			}
+			if selfThere {
+				// self position already there; remove as children are known
+				//				fmt.Printf("remove proof from pos %d\n", pos)
+
+				delete(proofTree, pos)
+				delete(proofTree, pos^1) // right? can delete both..?
+				break
+			}
+			// fmt.Printf("add proof from pos %d\n", pos^1)
+			proofTree[pos^1] = p.read(pos ^ 1)
+			pos = up1(pos, p.height())
+		}
+	}
+
+	var nodeSlice []Node
+
+	// run through partial tree to turn it into a slice
+	for pos, hash := range proofTree {
+		nodeSlice = append(nodeSlice, Node{pos, hash})
+	}
+	// fmt.Printf("made nodeSlice %d nodes\n", len(nodeSlice))
+
+	// sort the slice of nodes (even though we only want the hashes)
+	sortNodeSlice(nodeSlice)
+	// copy the sorted / in-order hashes into a hash slice
+	bp.Proof = make([]Hash, len(nodeSlice))
+
+	for i, n := range nodeSlice {
+		bp.Proof[i] = n.Val
+	}
+	if verbose {
+		fmt.Printf("blockproof targets: %v\n", bp.Targets)
+	}
+
+	return bp, nil
+}


### PR DESCRIPTION
This lets pollard do everything forest does.

Pollard now has a positionMap to track where hashes are within the forest.  It can provide proofs via GenProof, the same way forest does.
`NewFullPollard()` creates a pollard with the map enabled.  It will give errors or maybe crash if you try to use ProveBlock on a pollard that doesn't have a map.

Given this, you could technically delete all the Forest struct / methods / code.  There isn't an obvious way to keep the pollard on-disk though, so forest still does that.  Not sure which is faster though, an in-memory forest or a full pollard.