### PR TITLE
Refactor cmd/ and add rev*.dat block reading capability to util/

### DIFF
--- a/cmd/bridgenode/chain.go
+++ b/cmd/bridgenode/chain.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/mit-dci/lit/wire"
+	"github.com/btcsuite/btcd/wire"
 	"github.com/mit-dci/utreexo/cmd/util"
 	"github.com/mit-dci/utreexo/utreexo"
 )
@@ -13,14 +13,13 @@ import (
 // If a chain state is not present, chain is initialized to the genesis
 // returns forest, height, lastIndexOffsetHeight, pOffset and error
 func initBridgeNodeState(net wire.BitcoinNet, offsetFinished chan bool) (
-	*utreexo.Forest, int32, int32, int32, error) {
+	forest *utreexo.Forest, height int32, lastIndexOffsetHeight int32,
+	pOffset int32, err error) {
 
 	var offsetInitialized, forestInitialized bool
 
 	// bool to check if the offsetfile is present
 	offsetInitialized = util.HasAccess(util.OffsetFilePath)
-
-	var lastIndexOffsetHeight int32
 
 	// Default behavior is that the user should delete all offsetdata
 	// if they have new blk*.dat files to sync
@@ -42,9 +41,6 @@ func initBridgeNodeState(net wire.BitcoinNet, offsetFinished chan bool) (
 
 	// bool to check if the forestdata is present
 	forestInitialized = util.HasAccess(util.ForestFilePath)
-
-	var forest *utreexo.Forest
-	var height, pOffset int32
 
 	if forestInitialized {
 		var err error
@@ -70,7 +66,7 @@ func initBridgeNodeState(net wire.BitcoinNet, offsetFinished chan bool) (
 		}
 	}
 
-	return forest, height, lastIndexOffsetHeight, pOffset, nil
+	return
 }
 
 // saveBridgeNodeData saves the state of the bridgenode so that when the

--- a/cmd/bridgenode/chainio.go
+++ b/cmd/bridgenode/chainio.go
@@ -3,7 +3,7 @@ package bridge
 import (
 	"os"
 
-	"github.com/mit-dci/lit/wire"
+	"github.com/btcsuite/btcd/wire"
 	"github.com/mit-dci/utreexo/cmd/util"
 	"github.com/mit-dci/utreexo/utreexo"
 )
@@ -11,10 +11,8 @@ import (
 // createOffsetData restores the offsetfile needed to index the
 // blocks in the raw blk*.dat files.
 func createOffsetData(
-	net wire.BitcoinNet, offsetFinished chan bool) (int32, error) {
-
-	var lastIndexOffsetHeight int32
-	var err error
+	net wire.BitcoinNet, offsetFinished chan bool) (
+	lastIndexOffsetHeight int32, err error) {
 
 	// Set the Block Header hash
 	// buildOffsetFile matches the header hash to organize
@@ -28,15 +26,13 @@ func createOffsetData(
 		return 0, err
 	}
 
-	return lastIndexOffsetHeight, nil
+	return
 }
 
 // restoreLastProofFileOffset restores POffset from util.LastPOffsetFilePath
-func restoreLastProofFileOffset() (int32, error) {
-
-	// Gives the location of where a particular block height's proofs are
-	// Basically an index
-	var pOffset int32
+// pOffset represents the location of where a particular block height's proofs
+// are. Basically an index.
+func restoreLastProofFileOffset() (pOffset int32, err error) {
 
 	if util.HasAccess(util.LastPOffsetFilePath) {
 		f, err := os.OpenFile(
@@ -53,11 +49,11 @@ func restoreLastProofFileOffset() (int32, error) {
 		pOffset = util.BtI32(pOffsetByte[:])
 
 	}
-	return pOffset, nil
+	return
 }
 
 // createForest initializes forest
-func createForest() (*utreexo.Forest, error) {
+func createForest() (forest *utreexo.Forest, err error) {
 
 	// Where the forestfile exists
 	forestFile, err := os.OpenFile(
@@ -67,16 +63,14 @@ func createForest() (*utreexo.Forest, error) {
 	}
 
 	// Restores all the forest data
-	forest := utreexo.NewForest(forestFile)
+	forest = utreexo.NewForest(forestFile)
 
-	return forest, nil
+	return
 }
 
 // restoreForest restores forest fields based off the existing forestdata
 // on disk.
-func restoreForest() (*utreexo.Forest, error) {
-
-	var forest *utreexo.Forest
+func restoreForest() (forest *utreexo.Forest, err error) {
 
 	// Where the forestfile exists
 	forestFile, err := os.OpenFile(
@@ -96,13 +90,11 @@ func restoreForest() (*utreexo.Forest, error) {
 		return nil, err
 	}
 
-	return forest, nil
+	return
 }
 
 // restoreHeight restores height from util.ForestLastSyncedBlockHeightFilePath
-func restoreHeight() (int32, error) {
-
-	var height int32
+func restoreHeight() (height int32, err error) {
 
 	// if there is a heightfile, get the height from that
 	// heightFile saves the last block that was written to ttldb
@@ -120,13 +112,12 @@ func restoreHeight() (int32, error) {
 		}
 		height = util.BtI32(t[:])
 	}
-	return height, nil
+	return
 }
 
 // restoreLastIndexOffsetHeight restores the lastIndexOffsetHeight
-func restoreLastIndexOffsetHeight(offsetFinished chan bool) (int32, error) {
-
-	var lastIndexOffsetHeight int32
+func restoreLastIndexOffsetHeight(offsetFinished chan bool) (
+	lastIndexOffsetHeight int32, err error) {
 
 	// grab the last block height from currentoffsetheight
 	// currentoffsetheight saves the last height from the offsetfile
@@ -149,5 +140,5 @@ func restoreLastIndexOffsetHeight(offsetFinished chan bool) (int32, error) {
 	// to let stopParse() know that it shouldn't delete offsetfile
 	offsetFinished <- true
 
-	return lastIndexOffsetHeight, nil
+	return
 }

--- a/cmd/bridgenode/offsetfile.go
+++ b/cmd/bridgenode/offsetfile.go
@@ -55,13 +55,13 @@ func buildOffsetFile(tip util.Hash, offsetfinished chan bool) (int32, error) {
 
 	// write the last height of the offsetfile
 	// needed info for the main genproofs processes
-	currentOffsetHeightFile, err := os.OpenFile(
+	LastIndexOffsetHeightFile, err := os.OpenFile(
 		util.LastIndexOffsetHeightFilePath, os.O_CREATE|os.O_WRONLY, 0600)
 	if err != nil {
 		panic(err)
 	}
-	currentOffsetHeightFile.Write(util.U32tB(uint32(lastOffsetHeight))[:])
-	currentOffsetHeightFile.Close()
+	LastIndexOffsetHeightFile.Write(util.U32tB(uint32(lastOffsetHeight))[:])
+	LastIndexOffsetHeightFile.Close()
 
 	// Pass true to let stopParse() know we're finished
 	// and so it doesn't delete the offsetfile
@@ -79,17 +79,19 @@ func readRawHeadersFromFile(fileNum uint32) ([]util.RawHeaderData, error) {
 		panic(err)
 	}
 
-	fstat, err := f.Stat()
+	fStat, err := f.Stat()
 	if err != nil {
 		panic(err)
 	}
+
+	fSize := fStat.Size()
 
 	defer f.Close()
 	loc := int64(0)
 	offset := uint32(0) // where the block is located from the beginning of the file
 
 	// until offset is at the end of the file
-	for loc != fstat.Size() {
+	for loc != fSize {
 		b := new(util.RawHeaderData)
 		copy(b.FileNum[:], util.U32tB(fileNum))
 		copy(b.Offset[:], util.U32tB(offset))

--- a/cmd/csn/client.go
+++ b/cmd/csn/client.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/mit-dci/lit/wire"
+	"github.com/btcsuite/btcd/wire"
 	"github.com/mit-dci/utreexo/cmd/util"
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/opt"
@@ -52,10 +52,10 @@ func IBDClient(net wire.BitcoinNet,
 	var stop bool
 
 	// To send/receive blocks from blockreader()
-	bchan := make(chan util.BlockToWrite, 10)
+	txChan := make(chan util.TxToWrite, 10)
 
 	// Reads blocks asynchronously from blk*.dat files
-	go util.BlockReader(bchan,
+	go util.BlockReader(txChan,
 		lastIndexOffsetHeight, height, util.OffsetFilePath)
 
 	pFile, err := os.OpenFile(
@@ -75,9 +75,9 @@ func IBDClient(net wire.BitcoinNet,
 
 	for ; height != lastIndexOffsetHeight && stop != true; height++ {
 
-		b := <-bchan
+		txs := <-txChan
 
-		err = genPollard(b.Txs, b.Height, &totalTXOAdded,
+		err = genPollard(txs.Txs, txs.Height, &totalTXOAdded,
 			lookahead, &totalDels, plustime, pFile, pOffsetFile, lvdb, &p)
 		if err != nil {
 			panic(err)

--- a/cmd/csn/ibdsim.go
+++ b/cmd/csn/ibdsim.go
@@ -2,8 +2,9 @@ package csn
 
 import (
 	"fmt"
-	"github.com/mit-dci/lit/wire"
 	"os"
+
+	"github.com/btcsuite/btcd/wire"
 )
 
 var maxmalloc uint64

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -7,7 +7,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/mit-dci/lit/wire"
+	"github.com/btcsuite/btcd/wire"
 	bridge "github.com/mit-dci/utreexo/cmd/bridgenode"
 	"github.com/mit-dci/utreexo/cmd/csn"
 )

--- a/cmd/ttl/ttldb.go
+++ b/cmd/ttl/ttldb.go
@@ -4,19 +4,19 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/mit-dci/lit/wire"
+	"github.com/btcsuite/btcutil"
 	"github.com/mit-dci/utreexo/cmd/util"
 	"github.com/syndtr/goleveldb/leveldb"
 )
 
 //writeBlock sends off ttl info to dbWorker to be written to ttldb
-func WriteBlock(tx []*wire.MsgTx, tipnum int32,
+func WriteBlock(tx []*btcutil.Tx, tipnum int32,
 	batchan chan *leveldb.Batch, wg *sync.WaitGroup) error {
 
 	blockBatch := new(leveldb.Batch)
 
 	for blockindex, tx := range tx {
-		for _, in := range tx.TxIn {
+		for _, in := range tx.MsgTx().TxIn {
 			if blockindex > 0 { // skip coinbase "spend"
 				//hashing because blockbatch wants a byte slice
 				//TODO Maybe don't convert to a string?

--- a/cmd/ttl/ttlparse.go
+++ b/cmd/ttl/ttlparse.go
@@ -67,7 +67,7 @@ func lookerUpperWorker(
 	di.blockPos, di.txPos = blockPos, txPos
 
 	// build string and hash it (nice that this in parallel too)
-	utxostring := fmt.Sprintf("%s;%d", txid, txPos)
+	utxostring := fmt.Sprintf("%s:%d", txid, txPos)
 	opHash := util.HashFromString(utxostring)
 
 	// make DB lookup
@@ -80,7 +80,7 @@ func lookerUpperWorker(
 		panic(err)
 	}
 	if len(ttlbytes) != 4 {
-		fmt.Printf("val len %d, op %s;%d\n", len(ttlbytes), txid, txPos)
+		fmt.Printf("val len %d, op %s:%d\n", len(ttlbytes), txid, txPos)
 		panic("ded")
 	}
 

--- a/cmd/util/compress.go
+++ b/cmd/util/compress.go
@@ -1,0 +1,595 @@
+/*
+ * Taken from github.com/btcsuite/btcd/blockchain/compress.go with
+ * commit f3ec13030e4e828869954472cbc51ac36bee5c1d
+ *
+ * deserialize functions have been modified to take io.Reader as an argument
+ * instead of a byte slice.
+ */
+package util
+
+// Copyright (c) 2015-2016 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+import (
+	"io"
+
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/btcsuite/btcd/txscript"
+)
+
+// -----------------------------------------------------------------------------
+// A variable length quantity (VLQ) is an encoding that uses an arbitrary number
+// of binary octets to represent an arbitrarily large integer.  The scheme
+// employs a most significant byte (MSB) base-128 encoding where the high bit in
+// each byte indicates whether or not the byte is the final one.  In addition,
+// to ensure there are no redundant encodings, an offset is subtracted every
+// time a group of 7 bits is shifted out.  Therefore each integer can be
+// represented in exactly one way, and each representation stands for exactly
+// one integer.
+//
+// Another nice property of this encoding is that it provides a compact
+// representation of values that are typically used to indicate sizes.  For
+// example, the values 0 - 127 are represented with a single byte, 128 - 16511
+// with two bytes, and 16512 - 2113663 with three bytes.
+//
+// While the encoding allows arbitrarily large integers, it is artificially
+// limited in this code to an unsigned 64-bit integer for efficiency purposes.
+//
+// Example encodings:
+//           0 -> [0x00]
+//         127 -> [0x7f]                 * Max 1-byte value
+//         128 -> [0x80 0x00]
+//         129 -> [0x80 0x01]
+//         255 -> [0x80 0x7f]
+//         256 -> [0x81 0x00]
+//       16511 -> [0xff 0x7f]            * Max 2-byte value
+//       16512 -> [0x80 0x80 0x00]
+//       32895 -> [0x80 0xff 0x7f]
+//     2113663 -> [0xff 0xff 0x7f]       * Max 3-byte value
+//   270549119 -> [0xff 0xff 0xff 0x7f]  * Max 4-byte value
+//      2^64-1 -> [0x80 0xfe 0xfe 0xfe 0xfe 0xfe 0xfe 0xfe 0xfe 0x7f]
+//
+// References:
+//   https://en.wikipedia.org/wiki/Variable-length_quantity
+//   http://www.codecodex.com/wiki/Variable-Length_Integers
+// -----------------------------------------------------------------------------
+
+// serializeSizeVLQ returns the number of bytes it would take to serialize the
+// passed number as a variable-length quantity according to the format described
+// above.
+func serializeSizeVLQ(n uint64) int {
+	size := 1
+	for ; n > 0x7f; n = (n >> 7) - 1 {
+		size++
+	}
+
+	return size
+}
+
+// putVLQ serializes the provided number to a variable-length quantity according
+// to the format described above and returns the number of bytes of the encoded
+// value.  The result is placed directly into the passed byte slice which must
+// be at least large enough to handle the number of bytes returned by the
+// serializeSizeVLQ function or it will panic.
+func putVLQ(target []byte, n uint64) int {
+	offset := 0
+	for ; ; offset++ {
+		// The high bit is set when another byte follows.
+		highBitMask := byte(0x80)
+		if offset == 0 {
+			highBitMask = 0x00
+		}
+
+		target[offset] = byte(n&0x7f) | highBitMask
+		if n <= 0x7f {
+			break
+		}
+		n = (n >> 7) - 1
+	}
+
+	// Reverse the bytes so it is MSB-encoded.
+	for i, j := 0, offset; i < j; i, j = i+1, j-1 {
+		target[i], target[j] = target[j], target[i]
+	}
+
+	return offset + 1
+}
+
+// deserializeVLQ deserializes the provided variable-length quantity according
+// to the format described above.  It also returns the number of bytes
+// deserialized.
+// NOTE: This func is modified from btcd to take in io.Reader as an argument instead
+// of a byte slice
+func deserializeVLQ(r io.Reader) (uint64, int) {
+	var n uint64
+	var size int
+	for {
+		var val [1]byte
+		r.Read(val[:])
+		size++
+		n = (n << 7) | uint64(val[0]&0x7f)
+		if val[0]&0x80 != 0x80 {
+			break
+		}
+		n++
+	}
+
+	return n, size
+}
+
+// -----------------------------------------------------------------------------
+// In order to reduce the size of stored scripts, a domain specific compression
+// algorithm is used which recognizes standard scripts and stores them using
+// less bytes than the original script.  The compression algorithm used here was
+// obtained from Bitcoin Core, so all credits for the algorithm go to it.
+//
+// The general serialized format is:
+//
+//   <script size or type><script data>
+//
+//   Field                 Type     Size
+//   script size or type   VLQ      variable
+//   script data           []byte   variable
+//
+// The specific serialized format for each recognized standard script is:
+//
+// - Pay-to-pubkey-hash: (21 bytes) - <0><20-byte pubkey hash>
+// - Pay-to-script-hash: (21 bytes) - <1><20-byte script hash>
+// - Pay-to-pubkey**:    (33 bytes) - <2, 3, 4, or 5><32-byte pubkey X value>
+//   2, 3 = compressed pubkey with bit 0 specifying the y coordinate to use
+//   4, 5 = uncompressed pubkey with bit 0 specifying the y coordinate to use
+//   ** Only valid public keys starting with 0x02, 0x03, and 0x04 are supported.
+//
+// Any scripts which are not recognized as one of the aforementioned standard
+// scripts are encoded using the general serialized format and encode the script
+// size as the sum of the actual size of the script and the number of special
+// cases.
+// -----------------------------------------------------------------------------
+
+// The following constants specify the special constants used to identify a
+// special script type in the domain-specific compressed script encoding.
+//
+// NOTE: This section specifically does not use iota since these values are
+// serialized and must be stable for long-term storage.
+const (
+	// cstPayToPubKeyHash identifies a compressed pay-to-pubkey-hash script.
+	cstPayToPubKeyHash = 0
+
+	// cstPayToScriptHash identifies a compressed pay-to-script-hash script.
+	cstPayToScriptHash = 1
+
+	// cstPayToPubKeyComp2 identifies a compressed pay-to-pubkey script to
+	// a compressed pubkey.  Bit 0 specifies which y-coordinate to use
+	// to reconstruct the full uncompressed pubkey.
+	cstPayToPubKeyComp2 = 2
+
+	// cstPayToPubKeyComp3 identifies a compressed pay-to-pubkey script to
+	// a compressed pubkey.  Bit 0 specifies which y-coordinate to use
+	// to reconstruct the full uncompressed pubkey.
+	cstPayToPubKeyComp3 = 3
+
+	// cstPayToPubKeyUncomp4 identifies a compressed pay-to-pubkey script to
+	// an uncompressed pubkey.  Bit 0 specifies which y-coordinate to use
+	// to reconstruct the full uncompressed pubkey.
+	cstPayToPubKeyUncomp4 = 4
+
+	// cstPayToPubKeyUncomp5 identifies a compressed pay-to-pubkey script to
+	// an uncompressed pubkey.  Bit 0 specifies which y-coordinate to use
+	// to reconstruct the full uncompressed pubkey.
+	cstPayToPubKeyUncomp5 = 5
+
+	// numSpecialScripts is the number of special scripts recognized by the
+	// domain-specific script compression algorithm.
+	numSpecialScripts = 6
+)
+
+// isPubKeyHash returns whether or not the passed public key script is a
+// standard pay-to-pubkey-hash script along with the pubkey hash it is paying to
+// if it is.
+func isPubKeyHash(script []byte) (bool, []byte) {
+	if len(script) == 25 && script[0] == txscript.OP_DUP &&
+		script[1] == txscript.OP_HASH160 &&
+		script[2] == txscript.OP_DATA_20 &&
+		script[23] == txscript.OP_EQUALVERIFY &&
+		script[24] == txscript.OP_CHECKSIG {
+
+		return true, script[3:23]
+	}
+
+	return false, nil
+}
+
+// isScriptHash returns whether or not the passed public key script is a
+// standard pay-to-script-hash script along with the script hash it is paying to
+// if it is.
+func isScriptHash(script []byte) (bool, []byte) {
+	if len(script) == 23 && script[0] == txscript.OP_HASH160 &&
+		script[1] == txscript.OP_DATA_20 &&
+		script[22] == txscript.OP_EQUAL {
+
+		return true, script[2:22]
+	}
+
+	return false, nil
+}
+
+// isPubKey returns whether or not the passed public key script is a standard
+// pay-to-pubkey script that pays to a valid compressed or uncompressed public
+// key along with the serialized pubkey it is paying to if it is.
+//
+// NOTE: This function ensures the public key is actually valid since the
+// compression algorithm requires valid pubkeys.  It does not support hybrid
+// pubkeys.  This means that even if the script has the correct form for a
+// pay-to-pubkey script, this function will only return true when it is paying
+// to a valid compressed or uncompressed pubkey.
+func isPubKey(script []byte) (bool, []byte) {
+	// Pay-to-compressed-pubkey script.
+	if len(script) == 35 && script[0] == txscript.OP_DATA_33 &&
+		script[34] == txscript.OP_CHECKSIG && (script[1] == 0x02 ||
+		script[1] == 0x03) {
+
+		// Ensure the public key is valid.
+		serializedPubKey := script[1:34]
+		_, err := btcec.ParsePubKey(serializedPubKey, btcec.S256())
+		if err == nil {
+			return true, serializedPubKey
+		}
+	}
+
+	// Pay-to-uncompressed-pubkey script.
+	if len(script) == 67 && script[0] == txscript.OP_DATA_65 &&
+		script[66] == txscript.OP_CHECKSIG && script[1] == 0x04 {
+
+		// Ensure the public key is valid.
+		serializedPubKey := script[1:66]
+		_, err := btcec.ParsePubKey(serializedPubKey, btcec.S256())
+		if err == nil {
+			return true, serializedPubKey
+		}
+	}
+
+	return false, nil
+}
+
+// compressedScriptSize returns the number of bytes the passed script would take
+// when encoded with the domain specific compression algorithm described above.
+func compressedScriptSize(pkScript []byte) int {
+	// Pay-to-pubkey-hash script.
+	if valid, _ := isPubKeyHash(pkScript); valid {
+		return 21
+	}
+
+	// Pay-to-script-hash script.
+	if valid, _ := isScriptHash(pkScript); valid {
+		return 21
+	}
+
+	// Pay-to-pubkey (compressed or uncompressed) script.
+	if valid, _ := isPubKey(pkScript); valid {
+		return 33
+	}
+
+	// When none of the above special cases apply, encode the script as is
+	// preceded by the sum of its size and the number of special cases
+	// encoded as a variable length quantity.
+	return serializeSizeVLQ(uint64(len(pkScript)+numSpecialScripts)) +
+		len(pkScript)
+}
+
+// decodeCompressedScriptSize treats the passed serialized bytes as a compressed
+// script, possibly followed by other data, and returns the number of bytes it
+// occupies taking into account the special encoding of the script size by the
+// domain specific compression algorithm described above.
+// NOTE: This func is modified from btcd to take in io.Reader as an argument instead
+// of a byte slice
+func decodeCompressedScriptSize(r io.Reader) int {
+	scriptSize, bytesRead := deserializeVLQ(r)
+	if bytesRead == 0 {
+		return 0
+	}
+
+	switch scriptSize {
+	case cstPayToPubKeyHash:
+		return 21
+
+	case cstPayToScriptHash:
+		return 21
+
+	case cstPayToPubKeyComp2, cstPayToPubKeyComp3, cstPayToPubKeyUncomp4,
+		cstPayToPubKeyUncomp5:
+		return 33
+	}
+
+	scriptSize -= numSpecialScripts
+	scriptSize += uint64(bytesRead)
+	return int(scriptSize)
+}
+
+// putCompressedScript compresses the passed script according to the domain
+// specific compression algorithm described above directly into the passed
+// target byte slice.  The target byte slice must be at least large enough to
+// handle the number of bytes returned by the compressedScriptSize function or
+// it will panic.
+func putCompressedScript(target, pkScript []byte) int {
+	// Pay-to-pubkey-hash script.
+	if valid, hash := isPubKeyHash(pkScript); valid {
+		target[0] = cstPayToPubKeyHash
+		copy(target[1:21], hash)
+		return 21
+	}
+
+	// Pay-to-script-hash script.
+	if valid, hash := isScriptHash(pkScript); valid {
+		target[0] = cstPayToScriptHash
+		copy(target[1:21], hash)
+		return 21
+	}
+
+	// Pay-to-pubkey (compressed or uncompressed) script.
+	if valid, serializedPubKey := isPubKey(pkScript); valid {
+		pubKeyFormat := serializedPubKey[0]
+		switch pubKeyFormat {
+		case 0x02, 0x03:
+			target[0] = pubKeyFormat
+			copy(target[1:33], serializedPubKey[1:33])
+			return 33
+		case 0x04:
+			// Encode the oddness of the serialized pubkey into the
+			// compressed script type.
+			target[0] = pubKeyFormat | (serializedPubKey[64] & 0x01)
+			copy(target[1:33], serializedPubKey[1:33])
+			return 33
+		}
+	}
+
+	// When none of the above special cases apply, encode the unmodified
+	// script preceded by the sum of its size and the number of special
+	// cases encoded as a variable length quantity.
+	encodedSize := uint64(len(pkScript) + numSpecialScripts)
+	vlqSizeLen := putVLQ(target, encodedSize)
+	copy(target[vlqSizeLen:], pkScript)
+	return vlqSizeLen + len(pkScript)
+}
+
+// decompressScript returns the original script obtained by decompressing the
+// passed compressed script according to the domain specific compression
+// algorithm described above.
+//
+// NOTE: The script parameter must already have been proven to be long enough
+// to contain the number of bytes returned by decodeCompressedScriptSize or it
+// will panic.  This is acceptable since it is only an internal function.
+// NOTE(kcalvinalvin): This func is modified from btcd to take in io.Reader as
+// an argument instead of a byte slice
+func decompressScript(compressedPkScript io.Reader) []byte {
+	// Decode the script size and examine it for the special cases.
+	encodedScriptSize, _ := deserializeVLQ(compressedPkScript)
+	switch encodedScriptSize {
+	// Pay-to-pubkey-hash script.  The resulting script is:
+	// <OP_DUP><OP_HASH160><20 byte hash><OP_EQUALVERIFY><OP_CHECKSIG>
+	case cstPayToPubKeyHash:
+		pkScript := make([]byte, 25)
+		pkScript[0] = txscript.OP_DUP
+		pkScript[1] = txscript.OP_HASH160
+		pkScript[2] = txscript.OP_DATA_20
+		buf := make([]byte, 20)
+		_, err := io.ReadFull(compressedPkScript, buf)
+		if err != nil {
+			panic(err)
+		}
+		copy(pkScript[3:], buf)
+		pkScript[23] = txscript.OP_EQUALVERIFY
+		pkScript[24] = txscript.OP_CHECKSIG
+		return pkScript
+
+	// Pay-to-script-hash script.  The resulting script is:
+	// <OP_HASH160><20 byte script hash><OP_EQUAL>
+	case cstPayToScriptHash:
+		pkScript := make([]byte, 23)
+		pkScript[0] = txscript.OP_HASH160
+		pkScript[1] = txscript.OP_DATA_20
+		buf := make([]byte, 20)
+		_, err := io.ReadFull(compressedPkScript, buf)
+		if err != nil {
+			panic(err)
+		}
+		copy(pkScript[2:], buf)
+		pkScript[22] = txscript.OP_EQUAL
+		return pkScript
+
+	// Pay-to-compressed-pubkey script.  The resulting script is:
+	// <OP_DATA_33><33 byte compressed pubkey><OP_CHECKSIG>
+	case cstPayToPubKeyComp2, cstPayToPubKeyComp3:
+		pkScript := make([]byte, 35)
+		pkScript[0] = txscript.OP_DATA_33
+		pkScript[1] = byte(encodedScriptSize)
+		buf := make([]byte, 32)
+		_, err := io.ReadFull(compressedPkScript, buf)
+		if err != nil {
+			panic(err)
+		}
+		copy(pkScript[2:], buf)
+		pkScript[34] = txscript.OP_CHECKSIG
+		return pkScript
+
+	// Pay-to-uncompressed-pubkey script.  The resulting script is:
+	// <OP_DATA_65><65 byte uncompressed pubkey><OP_CHECKSIG>
+	case cstPayToPubKeyUncomp4, cstPayToPubKeyUncomp5:
+		// Change the leading byte to the appropriate compressed pubkey
+		// identifier (0x02 or 0x03) so it can be decoded as a
+		// compressed pubkey.  This really should never fail since the
+		// encoding ensures it is valid before compressing to this type.
+		compressedKey := make([]byte, 33)
+		buf := make([]byte, 33+1)
+		_, err := io.ReadFull(compressedPkScript, buf)
+		if err != nil {
+			panic(err)
+		}
+		compressedKey[0] = byte(encodedScriptSize - 2)
+		copy(compressedKey[1:], buf[1:])
+		key, err := btcec.ParsePubKey(compressedKey, btcec.S256())
+		if err != nil {
+			return nil
+		}
+
+		pkScript := make([]byte, 67)
+		pkScript[0] = txscript.OP_DATA_65
+		copy(pkScript[1:], key.SerializeUncompressed())
+		pkScript[66] = txscript.OP_CHECKSIG
+		return pkScript
+	}
+
+	// When none of the special cases apply, the script was encoded using
+	// the general format, so reduce the script size by the number of
+	// special cases and return the unmodified script.
+	scriptSize := int(encodedScriptSize - numSpecialScripts)
+	pkScript := make([]byte, scriptSize)
+
+	buf := make([]byte, scriptSize)
+	_, err := io.ReadFull(compressedPkScript, buf)
+	if err != nil {
+		panic(err)
+	}
+
+	copy(pkScript, buf)
+	return pkScript
+}
+
+// -----------------------------------------------------------------------------
+// In order to reduce the size of stored amounts, a domain specific compression
+// algorithm is used which relies on there typically being a lot of zeroes at
+// end of the amounts.  The compression algorithm used here was obtained from
+// Bitcoin Core, so all credits for the algorithm go to it.
+//
+// While this is simply exchanging one uint64 for another, the resulting value
+// for typical amounts has a much smaller magnitude which results in fewer bytes
+// when encoded as variable length quantity.  For example, consider the amount
+// of 0.1 BTC which is 10000000 satoshi.  Encoding 10000000 as a VLQ would take
+// 4 bytes while encoding the compressed value of 8 as a VLQ only takes 1 byte.
+//
+// Essentially the compression is achieved by splitting the value into an
+// exponent in the range [0-9] and a digit in the range [1-9], when possible,
+// and encoding them in a way that can be decoded.  More specifically, the
+// encoding is as follows:
+// - 0 is 0
+// - Find the exponent, e, as the largest power of 10 that evenly divides the
+//   value up to a maximum of 9
+// - When e < 9, the final digit can't be 0 so store it as d and remove it by
+//   dividing the value by 10 (call the result n).  The encoded value is thus:
+//   1 + 10*(9*n + d-1) + e
+// - When e==9, the only thing known is the amount is not 0.  The encoded value
+//   is thus:
+//   1 + 10*(n-1) + e   ==   10 + 10*(n-1)
+//
+// Example encodings:
+// (The numbers in parenthesis are the number of bytes when serialized as a VLQ)
+//            0 (1) -> 0        (1)           *  0.00000000 BTC
+//         1000 (2) -> 4        (1)           *  0.00001000 BTC
+//        10000 (2) -> 5        (1)           *  0.00010000 BTC
+//     12345678 (4) -> 111111101(4)           *  0.12345678 BTC
+//     50000000 (4) -> 47       (1)           *  0.50000000 BTC
+//    100000000 (4) -> 9        (1)           *  1.00000000 BTC
+//    500000000 (5) -> 49       (1)           *  5.00000000 BTC
+//   1000000000 (5) -> 10       (1)           * 10.00000000 BTC
+// -----------------------------------------------------------------------------
+
+// compressTxOutAmount compresses the passed amount according to the domain
+// specific compression algorithm described above.
+func compressTxOutAmount(amount uint64) uint64 {
+	// No need to do any work if it's zero.
+	if amount == 0 {
+		return 0
+	}
+
+	// Find the largest power of 10 (max of 9) that evenly divides the
+	// value.
+	exponent := uint64(0)
+	for amount%10 == 0 && exponent < 9 {
+		amount /= 10
+		exponent++
+	}
+
+	// The compressed result for exponents less than 9 is:
+	// 1 + 10*(9*n + d-1) + e
+	if exponent < 9 {
+		lastDigit := amount % 10
+		amount /= 10
+		return 1 + 10*(9*amount+lastDigit-1) + exponent
+	}
+
+	// The compressed result for an exponent of 9 is:
+	// 1 + 10*(n-1) + e   ==   10 + 10*(n-1)
+	return 10 + 10*(amount-1)
+}
+
+// decompressTxOutAmount returns the original amount the passed compressed
+// amount represents according to the domain specific compression algorithm
+// described above.
+func decompressTxOutAmount(amount uint64) uint64 {
+	// No need to do any work if it's zero.
+	if amount == 0 {
+		return 0
+	}
+
+	// The decompressed amount is either of the following two equations:
+	// x = 1 + 10*(9*n + d - 1) + e
+	// x = 1 + 10*(n - 1)       + 9
+	amount--
+
+	// The decompressed amount is now one of the following two equations:
+	// x = 10*(9*n + d - 1) + e
+	// x = 10*(n - 1)       + 9
+	exponent := amount % 10
+	amount /= 10
+
+	// The decompressed amount is now one of the following two equations:
+	// x = 9*n + d - 1  | where e < 9
+	// x = n - 1        | where e = 9
+	n := uint64(0)
+	if exponent < 9 {
+		lastDigit := amount%9 + 1
+		amount /= 9
+		n = amount*10 + lastDigit
+	} else {
+		n = amount + 1
+	}
+
+	// Apply the exponent.
+	for ; exponent > 0; exponent-- {
+		n *= 10
+	}
+
+	return n
+}
+
+// -----------------------------------------------------------------------------
+// Compressed transaction outputs consist of an amount and a public key script
+// both compressed using the domain specific compression algorithms previously
+// described.
+//
+// The serialized format is:
+//
+//   <compressed amount><compressed script>
+//
+//   Field                 Type     Size
+//     compressed amount   VLQ      variable
+//     compressed script   []byte   variable
+// -----------------------------------------------------------------------------
+
+// compressedTxOutSize returns the number of bytes the passed transaction output
+// fields would take when encoded with the format described above.
+func compressedTxOutSize(amount uint64, pkScript []byte) int {
+	return serializeSizeVLQ(compressTxOutAmount(amount)) +
+		compressedScriptSize(pkScript)
+}
+
+// putCompressedTxOut compresses the passed amount and script according to their
+// domain specific compression algorithms and encodes them directly into the
+// passed target byte slice with the format described above.  The target byte
+// slice must be at least large enough to handle the number of bytes returned by
+// the compressedTxOutSize function or it will panic.
+func putCompressedTxOut(target []byte, amount uint64, pkScript []byte) int {
+	offset := putVLQ(target, compressTxOutAmount(amount))
+	offset += putCompressedScript(target[offset:], pkScript)
+	return offset
+}

--- a/cmd/util/paths.go
+++ b/cmd/util/paths.go
@@ -7,6 +7,7 @@ import (
 
 // Directory paths
 var OffsetDirPath string = filepath.Join(".", "offsetdata")
+var RevOffsetDirPath string = filepath.Join(".", "revdata")
 var ProofDirPath string = filepath.Join(".", "proofdata")
 var ForestDirPath string = filepath.Join(".", "forestdata")
 var PollardDirPath string = filepath.Join(".", "pollarddata")
@@ -37,10 +38,14 @@ var ForestLastSyncedBlockHeightFilePath string = filepath.Join(ForestDirPath, "f
 var PollardFilePath string = filepath.Join(PollardDirPath, "pollardfile.dat")
 var PollardHeightFilePath string = filepath.Join(PollardDirPath, "pollardheight.dat")
 
-// MakePaths makes the necessary paths for all files
+// RevOffsetFilePath is the path for rev data file paths
+var RevOffsetFilePath string = filepath.Join(RevOffsetDirPath, "revoffsetfile")
+
+// MakePaths makes the neccessary paths for all files
 func MakePaths() {
 	os.MkdirAll(OffsetDirPath, os.ModePerm)
 	os.MkdirAll(ProofDirPath, os.ModePerm)
 	os.MkdirAll(ForestDirPath, os.ModePerm)
 	os.MkdirAll(PollardDirPath, os.ModePerm)
+	os.MkdirAll(RevOffsetDirPath, os.ModePerm)
 }

--- a/cmd/util/rev.go
+++ b/cmd/util/rev.go
@@ -1,0 +1,270 @@
+package util
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/btcsuite/btcd/wire"
+)
+
+// Wire Protocol version
+// Some btcd lib requires this as an argument
+// Technically the version is 70013 but many btcd
+// code is passing 0 on some Deserialization methods
+const pver uint32 = 0
+
+// MaxMessagePayload is the maximum bytes a message can be regardless of other
+// individual limits imposed by messages themselves.
+const MaxMessagePayload = (1024 * 1024 * 32) // 32MB
+
+/*
+ * All types here follow the Bitcoin Core implementation of the
+ * Undo blocks. One difference is that all the vectors are replaced
+ * with slices. This is just a language difference.
+ *
+ * Compression/Decompression and VarInt functions are all taken/using
+ * btcsuite packages.
+ */
+
+// RevBlock is the structure of how a block is stored in the
+// rev*.dat file the Bitcoin Core generates
+type RevBlock struct {
+	Magic [4]byte    // Network magic bytes
+	Size  [4]byte    // size of the BlockUndo record
+	Block *BlockUndo // acutal undo record
+	Hash  [32]byte   // 32 byte double sha256 hash of the block
+}
+
+// BlockUndo is the slice of undo information about transactions
+// Excludes the coinbase transaction
+// see github.com/bitcoin/bitcoin/src/undo.h
+type BlockUndo struct {
+	Tx []*TxUndo
+}
+
+// TxUndo contains the TxInUndo records.
+// see github.com/bitcoin/bitcoin/src/undo.h
+type TxUndo struct {
+	TxIn []*TxInUndo
+}
+
+// TxInUndo is the stucture of the undo transaction
+// Eveything is uncompressed here
+// see github.com/bitcoin/bitcoin/src/undo.h
+type TxInUndo struct {
+	Height int32
+
+	// Version of the original tx that created this tx
+	Varint uint64
+
+	// scriptPubKey of the spent UTXO
+	PKScript []byte
+
+	// Value of the spent UTXO
+	Amount uint64
+
+	// Whether if the TxInUndo is a coinbase or not
+	// Not actually included in the rev*.dat files
+	Coinbase bool
+}
+
+// GetRevBlock gets a single block from the rev*.dat file given the height
+func GetRevBlock(height int32, revOffsetFileName string) (
+	rBlock RevBlock, err error) {
+
+	var datFile [4]byte
+	var offset [4]byte
+
+	offsetFile, err := os.Open(revOffsetFileName)
+	if err != nil {
+		return rBlock, err
+	}
+
+	// offset file consists of 8 bytes per block
+	// height * 8 gives us the correct position for that block
+	offsetFile.Seek(int64(8*height), 0)
+
+	// Read file and offset for the block
+	offsetFile.Read(datFile[:])
+	offsetFile.Read(offset[:])
+
+	fileName := fmt.Sprintf("rev%05d.dat", int(BtU32(datFile[:])))
+
+	f, err := os.Open(fileName)
+	if err != nil {
+		return rBlock, err
+	}
+	// +8 skips the 8 bytes of magicbytes and load size
+	f.Seek(int64(BtU32(offset[:])+8), 0)
+
+	err = rBlock.Deserialize(f)
+	if err != nil {
+		return rBlock, err
+	}
+	f.Close()
+	offsetFile.Close()
+
+	return
+}
+
+// Deserialize takes a reader and reads a single block
+// Only initializes the Block var in RevBlock
+func (rb *RevBlock) Deserialize(r io.Reader) error {
+	txCount, err := wire.ReadVarInt(r, pver)
+	if err != nil {
+		return err
+	}
+
+	rb.Block = new(BlockUndo)
+	for i := uint64(0); i < txCount; i++ {
+		var tx TxUndo
+		err := tx.Deserialize(r)
+		if err != nil {
+			return err
+		}
+		rb.Block.Tx = append(rb.Block.Tx, &tx)
+	}
+	return nil
+}
+
+// Deserialize takes a reader and reads all the TxUndo data
+func (tx *TxUndo) Deserialize(r io.Reader) error {
+
+	// Read the Variable Integer
+	count, err := wire.ReadVarInt(r, pver)
+	if err != nil {
+		return err
+	}
+
+	for i := uint64(0); i < count; i++ {
+		var in TxInUndo
+		err := readTxInUndo(r, &in)
+		if err != nil {
+			return err
+		}
+		// NOTE: Sanity check. Should never be true
+		if in.PKScript == nil {
+			fmt.Println("WARNING nil script")
+		}
+		tx.TxIn = append(tx.TxIn, &in)
+	}
+	return nil
+}
+
+// readTxInUndo reads all the TxInUndo from the reader to the passed in txInUndo
+// variable
+func readTxInUndo(r io.Reader, ti *TxInUndo) error {
+	// nCode is how height is saved to the rev files
+	nCode, _ := deserializeVLQ(r)
+	ti.Height = int32(nCode / 2) // Height is saved as actual height * 2
+	ti.Coinbase = nCode&1 == 1   // Coinbase is odd. Saved as height * 2 + 1
+
+	// Only TxInUndos that have the height greater than 0
+	// Has varint that isn't 0. see
+	// github.com/bitcoin/bitcoin/blob/9cc7eba1b5651195c05473004c00021fe3856f30/src/undo.h#L42
+	if ti.Height > 0 {
+		varint, err := wire.ReadVarInt(r, pver)
+		if err != nil {
+			return err
+		}
+		if varint != 0 {
+			return fmt.Errorf("varint is %d\n", varint)
+		}
+		ti.Varint = varint
+	}
+
+	amount, _ := deserializeVLQ(r)
+	ti.Amount = decompressTxOutAmount(amount)
+
+	pkscript := decompressScript(r)
+	ti.PKScript = pkscript
+
+	return nil
+}
+
+// BuildRevOffsetFile builds an offset file for rev*.dat files
+// Just an index.
+func BuildRevOffsetFile() error {
+	offsetFile, err := os.OpenFile(RevOffsetFilePath,
+		os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		return err
+	}
+	defer offsetFile.Close()
+
+	for fileNum := uint32(0); ; fileNum++ {
+		fileName := fmt.Sprintf("rev%05d.dat", fileNum)
+		_, err := os.Stat(fileName)
+		if os.IsNotExist(err) {
+			fmt.Printf("%s doesn't exist; done building\n",
+				fileName)
+			break
+		}
+
+		err = writeOffset(fileNum, offsetFile)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// writeOffset reads the magic bytes from the rev*.dat files to make an index of
+// each individual revblock
+func writeOffset(fileNum uint32, offsetFile *os.File) error {
+	fileName := fmt.Sprintf("rev%05d.dat", fileNum)
+	f, err := os.Open(fileName)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	fStat, err := f.Stat()
+	if err != nil {
+		return err
+	}
+	fSize := fStat.Size()
+
+	offset := uint32(0)
+	loc := int64(0)
+	// Read until the location of the offset is bigger than that of the file size
+	for loc < fSize {
+		// check if Bitcoin magic bytes were read
+		var magicbytes [4]byte
+		_, err := f.Read(magicbytes[:])
+		if err != nil {
+			panic(err)
+		}
+		if CheckMagicByte(magicbytes) == false {
+			fmt.Println("non-magic byte read" +
+				"May have an incomplete rev*.dat file")
+			break
+		}
+
+		// read the 4 byte size of the load of the block
+		var size [4]byte
+		_, err = f.Read(size[:])
+		if err != nil {
+			return err
+		}
+
+		// Write the .dat file name and the
+		// offset the block can be found at
+		offsetFile.Write(U32tB(fileNum))
+		offsetFile.Write(U32tB(offset))
+
+		// offset for the next block from the current position
+		// skip the 32 bytes of double sha hash of the rev block
+		i, err := f.Seek(int64(LBtU32(size[:]))+32, 1)
+		if err != nil {
+			return err
+		}
+		// set offset
+		offset = uint32(i)
+		// advance location
+		loc += i
+
+	}
+	return nil
+}

--- a/cmd/util/rev_test.go
+++ b/cmd/util/rev_test.go
@@ -1,0 +1,67 @@
+package util
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+func TestGetRevBlocks(t *testing.T) {
+	// Makes neccessary directories
+	MakePaths()
+
+	// Builds an index
+	// takes less than 1/10th of a  second
+	err := BuildRevOffsetFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Gets blocks 1 ~ 700,000
+	for i := int32(0); i < 700000; i++ {
+		_, err := GetRevBlock(i, RevOffsetFilePath)
+		if err != nil {
+			t.Log("Failed at height:", i+1)
+			// If it does fail, delete the created directories
+			os.RemoveAll(OffsetDirPath)
+			os.RemoveAll(ProofDirPath)
+			os.RemoveAll(ForestDirPath)
+			os.RemoveAll(PollardDirPath)
+			os.RemoveAll(RevOffsetDirPath)
+			t.Fatal(err)
+		}
+	}
+	// Delete all the directories
+	os.RemoveAll(OffsetDirPath)
+	os.RemoveAll(ProofDirPath)
+	os.RemoveAll(ForestDirPath)
+	os.RemoveAll(PollardDirPath)
+	os.RemoveAll(RevOffsetDirPath)
+}
+
+func TestGetOneRevBlock(t *testing.T) {
+	MakePaths()
+
+	err := BuildRevOffsetFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rb, err := GetRevBlock(382, RevOffsetFilePath) // fetches block 383
+	if err != nil {
+		t.Log("Failed at height:", 382+1)
+		os.RemoveAll(OffsetDirPath)
+		os.RemoveAll(ProofDirPath)
+		os.RemoveAll(ForestDirPath)
+		os.RemoveAll(PollardDirPath)
+		os.RemoveAll(RevOffsetDirPath)
+		t.Fatal(err)
+	}
+	fmt.Println("Block:", rb.Block)
+	fmt.Println("Txs:", rb.Block.Tx)
+	os.RemoveAll(OffsetDirPath)
+	os.RemoveAll(ProofDirPath)
+	os.RemoveAll(ForestDirPath)
+	os.RemoveAll(PollardDirPath)
+	os.RemoveAll(RevOffsetDirPath)
+}

--- a/cmd/util/types.go
+++ b/cmd/util/types.go
@@ -3,7 +3,8 @@ package util
 import (
 	"crypto/sha256"
 
-	"github.com/mit-dci/lit/wire"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcutil"
 )
 
 type Hash [32]byte
@@ -40,19 +41,35 @@ type Txotx struct {
 	DeathHeights []uint32
 }
 
-//Header data read off the .dat file.
-//FileNum is the .dat file number
-//Offset is where it is in the .dat file.
-//CurrentHeaderHash is the 80byte header double hashed
-//Prevhash is the 32 byte previous header included in the 80byte header.
-type RawHeaderData struct {
-	CurrentHeaderHash [32]byte
-	Prevhash          [32]byte
-	FileNum           [4]byte
-	Offset            [4]byte
+// Tx defines a bitcoin transaction that provides easier and more efficient
+// manipulation of raw transactions.  It also memoizes the hash for the
+// transaction on its first access so subsequent accesses don't have to repeat
+// the relatively expensive hashing operations.
+type ProofTx struct {
+	msgTx         *wire.MsgTx // Underlying MsgTx
+	txHash        *Hash       // Cached transaction hash
+	txHashWitness *Hash       // Cached transaction witness hash
+	txHasWitness  *bool       // If the transaction has witness data
+	txIndex       int         // Position within a block or TxIndexUnknown
 }
 
-type BlockToWrite struct {
-	Txs    []*wire.MsgTx
+// RawHeaderData is used for blk*.dat offsetfile building
+// Used for ordering blocks as they aren't stored in order in the blk files.
+// Includes 32 bytes of sha256 hash along with other variables
+// needed for offsetfile building.
+type RawHeaderData struct {
+	// CurrentHeaderHash is the double hashed 32 byte header
+	CurrentHeaderHash [32]byte
+	// Prevhash is the 32 byte previous header included in the 80byte header.
+	// Needed for ordering
+	Prevhash [32]byte
+	// FileNum is the blk*.dat file number
+	FileNum [4]byte
+	// Offset is where it is in the .dat file.
+	Offset [4]byte
+}
+
+type TxToWrite struct {
+	Txs    []*btcutil.Tx
 	Height int32
 }


### PR DESCRIPTION
Please do test out the rev_test.go file. You do need to copy rev*.dat files to the util/ directory for the test to work.