### PR TITLE
Fix undo tests

### DIFF
--- a/utreexo/forest.go
+++ b/utreexo/forest.go
@@ -318,11 +318,11 @@ func (f *Forest) reHash(dirt []uint64) error {
 }
 
 // cleanup removes extraneous hashes from the forest.  Currently only the bottom
+// Probably don't need this at all, if everything else is working.
 func (f *Forest) cleanup(overshoot uint64) {
 	for p := f.numLeaves; p < f.numLeaves+overshoot; p++ {
 		f.positions.rem(f.data.read(p)) // clear position data
-		// TODO ^^^^ that probably does nothing. or at least should...
-		f.data.write(p, empty) // clear forest
+		f.data.write(p, empty)          // clear forest
 	}
 }
 
@@ -383,7 +383,7 @@ func (f *Forest) Modify(adds []LeafTXO, dels []uint64) (*undoBlock, error) {
 	if err != nil {
 		return nil, err
 	}
-	f.cleanup(uint64(numdels))
+	// f.cleanup(uint64(numdels))
 
 	// save the leaves past the edge for undo
 	// dels hasn't been mangled by remove up above, right?

--- a/utreexo/forest.go
+++ b/utreexo/forest.go
@@ -364,6 +364,10 @@ func (f *Forest) addv2(adds []LeafTXO) {
 func (f *Forest) Modify(adds []LeafTXO, dels []uint64) (*undoBlock, error) {
 	numdels, numadds := len(dels), len(adds)
 	delta := int64(numadds - numdels) // watch 32/64 bit
+	if int64(f.numLeaves)+delta < 0 {
+		return nil, fmt.Errorf("can't delete %d leaves, only %d exist",
+			len(dels), f.numLeaves)
+	}
 	// remap to expand the forest if needed
 	for int64(f.numLeaves)+delta > int64(1<<f.height) {
 		// fmt.Printf("current cap %d need %d\n",
@@ -420,10 +424,10 @@ func (f *Forest) reMap(destHeight uint8) error {
 	}
 	// I don't think you ever need to remap down.  It really doesn't
 	// matter.  Something to program someday if you feel like it for fun.
-	fmt.Printf("size is %d\n", f.data.size())
+	// fmt.Printf("size is %d\n", f.data.size())
 	// height increase
 	f.data.resize(2 << destHeight)
-	fmt.Printf("size is %d\n", f.data.size())
+	// fmt.Printf("size is %d\n", f.data.size())
 	pos := uint64(1 << destHeight) // leftmost position of row 1
 	reach := pos >> 1              // how much to next row up
 	// start on row 1, row 0 doesn't move

--- a/utreexo/forestdata.go
+++ b/utreexo/forestdata.go
@@ -34,19 +34,22 @@ type ramForestData struct {
 // reads from specified location.  If you read beyond the bounds that's on you
 // and it'll crash
 func (r *ramForestData) read(pos uint64) Hash {
-	if r.m[pos] == empty {
-		fmt.Printf("\tuseless read empty at pos %d\n", pos)
-	}
+	// if r.m[pos] == empty {
+	// 	fmt.Printf("\tuseless read empty at pos %d\n", pos)
+	// }
 	return r.m[pos]
 }
 
 // writeHash writes a hash.  Don't go out of bounds.
 func (r *ramForestData) write(pos uint64, h Hash) {
-	if h == empty {
-		fmt.Printf("\tWARNING!! write empty at pos %d\n", pos)
-	}
+	// if h == empty {
+	// 	fmt.Printf("\tWARNING!! write empty at pos %d\n", pos)
+	// }
 	r.m[pos] = h
 }
+
+// TODO there's lots of empty writes as well, mostly in resize?  Anyway could
+// be optimized away.
 
 // swapHash swaps 2 hashes.  Don't go out of bounds.
 func (r *ramForestData) swapHash(a, b uint64) {

--- a/utreexo/forestdata.go
+++ b/utreexo/forestdata.go
@@ -34,14 +34,17 @@ type ramForestData struct {
 // reads from specified location.  If you read beyond the bounds that's on you
 // and it'll crash
 func (r *ramForestData) read(pos uint64) Hash {
-	// if r.m[pos] == empty {
-	// fmt.Printf("\tWARNING!!empty at pos %d\n", pos)
-	// }
+	if r.m[pos] == empty {
+		fmt.Printf("\tuseless read empty at pos %d\n", pos)
+	}
 	return r.m[pos]
 }
 
 // writeHash writes a hash.  Don't go out of bounds.
 func (r *ramForestData) write(pos uint64, h Hash) {
+	if h == empty {
+		fmt.Printf("\tWARNING!! write empty at pos %d\n", pos)
+	}
 	r.m[pos] = h
 }
 

--- a/utreexo/undo.go
+++ b/utreexo/undo.go
@@ -142,7 +142,7 @@ func (f *Forest) BuildUndoData(numadds uint64, dels []uint64) *undoBlock {
 	for i, _ := range ub.positions {
 		ub.hashes[i] = f.data.read(f.numLeaves + uint64(i))
 		if ub.hashes[i] == empty {
-			fmt.Printf("warning, wrote  empty hash for position %d\n",
+			fmt.Printf("warning, wrote empty hash for position %d\n",
 				ub.positions[i])
 		}
 	}

--- a/utreexo/undo_test.go
+++ b/utreexo/undo_test.go
@@ -90,6 +90,7 @@ func undoAddDelOnce(numStart, numAdds, numDels uint32) error {
 	// --------------- block 0
 	// make starting forest with numStart leaves, and store tops
 	adds, _ := sc.NextBlock(numStart)
+	fmt.Printf("adding %d leaves\n", numStart)
 	_, err := f.Modify(adds, nil)
 	if err != nil {
 		return err
@@ -114,6 +115,8 @@ func undoAddDelOnce(numStart, numAdds, numDels uint32) error {
 	if err != nil {
 		return err
 	}
+
+	fmt.Printf("block 1 add %d rem %d\n", numAdds, numDels)
 
 	ub, err := f.Modify(adds, bp.Targets)
 	if err != nil {


### PR DESCRIPTION
Seems like the main problem was the `cleanup` function... getting rid of it fixed all the problems with undo.

There are still a whole bunch of useless reads and writes of empty data (32 bytes of 0s) happening, so could look into those and stop that to speed up i/o.  But they don't look like they break anything.