### PR TITLE
util/: Fix rev.go and compress.go

### DIFF
--- a/cmd/util/compress.go
+++ b/cmd/util/compress.go
@@ -420,13 +420,14 @@ func decompressScript(compressedPkScript io.Reader) []byte {
 		// compressed pubkey.  This really should never fail since the
 		// encoding ensures it is valid before compressing to this type.
 		compressedKey := make([]byte, 33)
-		buf := make([]byte, 33+1)
+		compressedKey[0] = byte(encodedScriptSize - 2)
+
+		buf := make([]byte, 32)
 		_, err := io.ReadFull(compressedPkScript, buf)
 		if err != nil {
 			panic(err)
 		}
-		compressedKey[0] = byte(encodedScriptSize - 2)
-		copy(compressedKey[1:], buf[1:])
+		copy(compressedKey[1:], buf)
 		key, err := btcec.ParsePubKey(compressedKey, btcec.S256())
 		if err != nil {
 			return nil
@@ -450,7 +451,6 @@ func decompressScript(compressedPkScript io.Reader) []byte {
 	if err != nil {
 		panic(err)
 	}
-
 	copy(pkScript, buf)
 	return pkScript
 }

--- a/cmd/util/rev_test.go
+++ b/cmd/util/rev_test.go
@@ -6,6 +6,11 @@ import (
 	"testing"
 )
 
+/*
+ * TODO: These tests require rev*.dat files in the util directory.
+ * Copy them over to test.
+ */
+
 func TestGetRevBlocks(t *testing.T) {
 	// Makes neccessary directories
 	MakePaths()
@@ -17,9 +22,9 @@ func TestGetRevBlocks(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Gets blocks 1 ~ 700,000
-	for i := int32(0); i < 700000; i++ {
-		_, err := GetRevBlock(i, RevOffsetFilePath)
+	// Gets blocks 1 ~ 300,001
+	for i := int32(0); i < 300000; i++ {
+		rb, err := GetRevBlock(i, RevOffsetFilePath)
 		if err != nil {
 			t.Log("Failed at height:", i+1)
 			// If it does fail, delete the created directories
@@ -30,6 +35,14 @@ func TestGetRevBlocks(t *testing.T) {
 			os.RemoveAll(RevOffsetDirPath)
 			t.Fatal(err)
 		}
+		fmt.Println("height", i+1)
+		for _, tx := range rb.Block.Tx {
+			for i, txin := range tx.TxIn {
+				fmt.Println("txcount:", i)
+				fmt.Println(txin)
+			}
+		}
+
 	}
 	// Delete all the directories
 	os.RemoveAll(OffsetDirPath)
@@ -47,7 +60,14 @@ func TestGetOneRevBlock(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rb, err := GetRevBlock(382, RevOffsetFilePath) // fetches block 383
+	// Any arbitrary block will do here for testing
+	// 382 actually fetches block 383
+	rb, err := GetRevBlock(382, RevOffsetFilePath)
+	for _, tx := range rb.Block.Tx {
+		for _, txin := range tx.TxIn {
+			fmt.Println(txin)
+		}
+	}
 	if err != nil {
 		t.Log("Failed at height:", 382+1)
 		os.RemoveAll(OffsetDirPath)
@@ -57,8 +77,6 @@ func TestGetOneRevBlock(t *testing.T) {
 		os.RemoveAll(RevOffsetDirPath)
 		t.Fatal(err)
 	}
-	fmt.Println("Block:", rb.Block)
-	fmt.Println("Txs:", rb.Block.Tx)
 	os.RemoveAll(OffsetDirPath)
 	os.RemoveAll(ProofDirPath)
 	os.RemoveAll(ForestDirPath)


### PR DESCRIPTION
Fixed a bug in RevOffset generation and another in decompressing the
PKscript.