### PR TITLE
Add test deleting keys 1,0 from two-leaf tree

### DIFF
--- a/utreexo/forest_test.go
+++ b/utreexo/forest_test.go
@@ -5,6 +5,21 @@ import (
 	"testing"
 )
 
+func TestDeleteReverseOrder(t *testing.T) {
+	f := NewForest(nil)
+	leaf1 := LeafTXO { Hash: Hash { 1 } }
+	leaf2 := LeafTXO { Hash: Hash { 2 } }
+	_, err := f.Modify([]LeafTXO { leaf1, leaf2 }, nil)
+	if err != nil {
+		t.Fail()
+	}
+	_, err = f.Modify(nil, []uint64 { 1, 0 })
+	if err != nil {
+		t.Log(err)
+		t.Fatal("could not delete leaves 1 and 0")
+	}
+}
+
 func TestForestAddDel(t *testing.T) {
 
 	numAdds := uint32(10)


### PR DESCRIPTION
This is causing a panic on master.

I have let the commit message note the commit ID of master as it is currently, so that the fix can be merged first, if you like. That way, the commit description will still make sense.

Note that if you add another leaf, it still panics with the same error message. I am saying this because I suspected it was because of emptying the tree. But it seems it wasn't.