### PR TITLE
util/utils.go: Panic when rev*.dat files are not present

### DIFF
--- a/cmd/util/utils.go
+++ b/cmd/util/utils.go
@@ -90,6 +90,9 @@ func BlockAndRevReader(
 		}
 
 		rb, err := GetRevBlock(curHeight, RevOffsetFilePath)
+		if err != nil {
+			panic(err)
+		}
 
 		bnr := BlockAndRev{Height: curHeight, Blk: blk, Rev: rb}
 


### PR DESCRIPTION
This will let users know that they're missing rev*.dat files