### PR TITLE
accumulator: fix race condition in tests

### DIFF
--- a/accumulator/hasher.go
+++ b/accumulator/hasher.go
@@ -17,7 +17,8 @@ type hashableNode struct {
 
 func (n *hashableNode) run(wg *sync.WaitGroup) {
 	// fmt.Printf("hasher about to replace %x\n", n.dest.data[:4])
-	n.dest.data = n.sib.auntOp()
+	n.dest.safeAssignData(n.sib.auntOp())
+	// n.dest.data = n.sib.auntOp()
 	// fmt.Printf("hasher finished %x %x -> %x\n",
 	// n.sib.niece[0].data[:4], n.sib.niece[1].data[:4], n.dest.data[:4])
 	wg.Done()

--- a/accumulator/pollardutil.go
+++ b/accumulator/pollardutil.go
@@ -45,9 +45,7 @@ func (n *polNode) auntOp() Hash {
 }
 
 // safeAssignData assigns the Hash to the data member of the polNode.
-// This is threadsafe. TODO: use an atomic Value instead of a Hash and benchmark
-// performance - there might be a performance benefit, but probably only if we
-// don't read more than write data from polNodes
+// This is threadsafe. TODO: remove Mutex from polNode, fix duplicate hashing
 func (n *polNode) safeAssignData(newData Hash) {
 	n.dataMtx.Lock()
 	n.data = newData


### PR DESCRIPTION
When running the tests with the `-race` flag, there is a data race that happens when writing to the `data` field of a `polNode`. I suspect this is the same data race and fixes #103, so I just wrote a thread safe assign for data. This uses a mutex so it won't help performance, and I'm not entirely sure when the data race would mess things up.