### PR TITLE
accumulator: make dedupeSwapDirt work as documented

### DIFF
--- a/accumulator/utils.go
+++ b/accumulator/utils.go
@@ -400,7 +400,7 @@ func dedupeSwapDirt(a []uint64, b []arrow) []uint64 {
 	idxb := 0
 	for j := 0; j < maxa; j++ {
 		// skip over swap destinations less than current dirt
-		for idxb < maxb && a[j] < b[idxb].to {
+		for idxb < maxb && b[idxb].to < a[j] {
 			idxb++
 		}
 		if idxb == maxb { // done


### PR DESCRIPTION
The util function `dedupeSwapDirt` currently does not work as intended/documented.
https://github.com/mit-dci/utreexo/blob/cb5c021b3d001a5f5b4dd3eedce8aac034a5dbd2/accumulator/utils.go#L389-L392

Example:
```go
dedupeSwapDirt([]uint64{1, 4, 5, 10, 16}, []arrow{{1, 4}, {1, 11}, {1, 16}})
```
This currently results in `[1 4 5 10 16]` but it should result in `[1, 5, 10]`.
