### PR TITLE
Fix regtest panic

### DIFF
--- a/bridgenode/offsetfile.go
+++ b/bridgenode/offsetfile.go
@@ -187,7 +187,7 @@ func readRawHeadersFromFile(fileNum uint32) ([]util.RawHeaderData, error) {
 		var blockheader [80]byte
 		f.Read(blockheader[:])
 
-		copy(b.Prevhash[:], blockheader[4:32])
+		copy(b.Prevhash[:], blockheader[4:32+4])
 
 		// create block hash
 		// double sha256 needed with Bitcoin

--- a/util/utils.go
+++ b/util/utils.go
@@ -566,7 +566,8 @@ func I64tB(i int64) []byte {
 // Checks only for testnet3 and mainnet
 func CheckMagicByte(bytesgiven [4]byte) bool {
 	if bytesgiven != [4]byte{0x0b, 0x11, 0x09, 0x07} && //testnet
-		bytesgiven != [4]byte{0xf9, 0xbe, 0xb4, 0xd9} { // mainnet
+		bytesgiven != [4]byte{0xf9, 0xbe, 0xb4, 0xd9} && // mainnet
+		bytesgiven != [4]byte{0xfa, 0xbf, 0xb5, 0xda} { // regtest
 		fmt.Printf("got non magic bytes %x, finishing\n", bytesgiven)
 		return false
 	} else {


### PR DESCRIPTION
* Regtest has its own magic bytes
* only 28 bytes were read when reading previous blockhashes from blk.dat files.