### PR TITLE
util: Refactor integer conversion functions

### DIFF
--- a/accumulator/forest.go
+++ b/accumulator/forest.go
@@ -1,6 +1,7 @@
 package accumulator
 
 import (
+	"encoding/binary"
 	"fmt"
 	"os"
 	"time"
@@ -544,12 +545,10 @@ func RestoreForest(miscForestFile *os.File, forestFile *os.File) (*Forest, error
 	f.positionMap = make(map[MiniHash]uint64)
 
 	// This restores the numLeaves
-	var byteLeaves [8]byte
-	_, err := miscForestFile.Read(byteLeaves[:])
+	err := binary.Read(miscForestFile, binary.BigEndian, &f.numLeaves)
 	if err != nil {
 		return nil, err
 	}
-	f.numLeaves = BtU64(byteLeaves[:])
 	fmt.Println("Forest leaves:", f.numLeaves)
 
 	// This restores the positionMap
@@ -567,12 +566,10 @@ func RestoreForest(miscForestFile *os.File, forestFile *os.File) (*Forest, error
 	}
 
 	// This restores the rows
-	var byteRows [1]byte
-	_, err = miscForestFile.Read(byteRows[:])
+	binary.Read(miscForestFile, binary.BigEndian, &f.rows)
 	if err != nil {
 		return nil, err
 	}
-	f.rows = BtU8(byteRows[:])
 	fmt.Println("Forest rows:", f.rows)
 	fmt.Println("Done restoring forest")
 
@@ -593,10 +590,17 @@ func (f *Forest) PrintPositionMap() string {
 func (f *Forest) WriteForest(miscForestFile *os.File) error {
 	fmt.Println("numLeaves=", f.numLeaves)
 	fmt.Println("f.rows=", f.rows)
-	_, err := miscForestFile.WriteAt(append(U64tB(f.numLeaves), U8tB(f.rows)...), 0)
+
+	err := binary.Write(miscForestFile, binary.BigEndian, f.numLeaves)
 	if err != nil {
 		return err
 	}
+
+	err = binary.Write(miscForestFile, binary.BigEndian, f.rows)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/accumulator/utils.go
+++ b/accumulator/utils.go
@@ -1,8 +1,6 @@
 package accumulator
 
 import (
-	"bytes"
-	"encoding/binary"
 	"fmt"
 	"sort"
 )
@@ -463,61 +461,4 @@ func BinString(leaves uint64) string {
 		s += output[z] + "\n"
 	}
 	return s
-}
-
-// BtU32 : 4 byte slice to uint32.  Returns ffffffff if something doesn't work.
-func BtU32(b []byte) uint32 {
-	if len(b) != 4 {
-		fmt.Printf("Got %x to BtU32 (%d bytes)\n", b, len(b))
-		return 0xffffffff
-	}
-	var i uint32
-	buf := bytes.NewBuffer(b)
-	binary.Read(buf, binary.BigEndian, &i)
-	return i
-}
-
-// U32tB : uint32 to 4 bytes.  Always works.
-func U32tB(i uint32) []byte {
-	var buf bytes.Buffer
-	binary.Write(&buf, binary.BigEndian, i)
-	return buf.Bytes()
-}
-
-// BtU64 : 8 bytes to uint64.  returns ffff. if it doesn't work.
-func BtU64(b []byte) uint64 {
-	if len(b) != 8 {
-		fmt.Printf("Got %x to BtU64 (%d bytes)\n", b, len(b))
-		return 0xffffffffffffffff
-	}
-	var i uint64
-	buf := bytes.NewBuffer(b)
-	binary.Read(buf, binary.BigEndian, &i)
-	return i
-}
-
-// U64tB : uint64 to 8 bytes.  Always works.
-func U64tB(i uint64) []byte {
-	var buf bytes.Buffer
-	binary.Write(&buf, binary.BigEndian, i)
-	return buf.Bytes()
-}
-
-// BtU8 : 1 byte to uint8.  returns ffff. if it doesn't work.
-func BtU8(b []byte) uint8 {
-	if len(b) != 1 {
-		fmt.Printf("Got %x to BtU8 (%d bytes)\n", b, len(b))
-		return 0xff
-	}
-	var i uint8
-	buf := bytes.NewBuffer(b)
-	binary.Read(buf, binary.BigEndian, &i)
-	return i
-}
-
-// U8tB : uint8 to a byte.  Always works.
-func U8tB(i uint8) []byte {
-	var buf bytes.Buffer
-	binary.Write(&buf, binary.BigEndian, i)
-	return buf.Bytes()
 }

--- a/bridgenode/chain.go
+++ b/bridgenode/chain.go
@@ -1,6 +1,7 @@
 package bridgenode
 
 import (
+	"encoding/binary"
 	"fmt"
 	"os"
 	"sync"
@@ -80,7 +81,7 @@ func saveBridgeNodeData(
 		if err != nil {
 			return err
 		}
-		_, err = heightFile.WriteAt(util.I32tB(height), 0)
+		err = binary.Write(heightFile, binary.BigEndian, height)
 		if err != nil {
 			return err
 		}

--- a/bridgenode/chainio.go
+++ b/bridgenode/chainio.go
@@ -1,6 +1,7 @@
 package bridgenode
 
 import (
+	"encoding/binary"
 	"os"
 
 	"github.com/btcsuite/btcd/wire"
@@ -89,12 +90,10 @@ func restoreHeight() (height int32, err error) {
 		if err != nil {
 			return 0, err
 		}
-		var t [4]byte
-		_, err = heightFile.Read(t[:])
+		err = binary.Read(heightFile, binary.BigEndian, &height)
 		if err != nil {
 			return 0, err
 		}
-		height = util.BtI32(t[:])
 	}
 	return
 }
@@ -103,23 +102,18 @@ func restoreHeight() (height int32, err error) {
 func restoreLastIndexOffsetHeight(offsetFinished chan bool) (
 	lastIndexOffsetHeight int32, err error) {
 
-	// grab the last block height from currentoffsetheight
-	// currentoffsetheight saves the last height from the offsetfile
-	var lastIndexOffsetHeightByte [4]byte
-
 	f, err := os.OpenFile(
 		util.LastIndexOffsetHeightFilePath, os.O_CREATE|os.O_RDWR, 0600)
 	if err != nil {
 		return 0, err
 	}
-	_, err = f.Read(lastIndexOffsetHeightByte[:])
+
+	// grab the last block height from currentoffsetheight
+	// currentoffsetheight saves the last height from the offsetfile
+	err = binary.Read(f, binary.BigEndian, &lastIndexOffsetHeight)
 	if err != nil {
 		return 0, err
 	}
-
-	f.Read(lastIndexOffsetHeightByte[:])
-	lastIndexOffsetHeight = util.BtI32(lastIndexOffsetHeightByte[:])
-
 	// if there is a offset file, we should pass true to offsetFinished
 	// to let stopParse() know that it shouldn't delete offsetfile
 	offsetFinished <- true

--- a/csn/chainio.go
+++ b/csn/chainio.go
@@ -1,6 +1,7 @@
 package csn
 
 import (
+	"encoding/binary"
 	"os"
 	"sync"
 
@@ -37,12 +38,11 @@ func restorePollardHeight() (height int32, err error) {
 	if err != nil {
 		return 0, err
 	}
-	var t [4]byte
-	_, err = pHeightFile.Read(t[:])
+
+	err = binary.Read(pHeightFile, binary.BigEndian, &height)
 	if err != nil {
 		return 0, err
 	}
-	height = util.BtI32(t[:])
 
 	return
 }
@@ -62,7 +62,7 @@ func saveIBDsimData(height int32, p accumulator.Pollard) error {
 			return err
 		}
 		// write to the heightfile
-		_, err = pHeightFile.WriteAt(util.U32tB(uint32(height)), 0)
+		err = binary.Write(pHeightFile, binary.BigEndian, height)
 		if err != nil {
 			return err
 		}

--- a/util/rev.go
+++ b/util/rev.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"encoding/binary"
 	"fmt"
 	"io"
 	"os"
@@ -71,8 +72,8 @@ func GetRevBlock(height int32, revOffsetFileName string) (
 	}
 	height--
 
-	var datFile [4]byte
-	var offset [4]byte
+	var datFile uint32
+	var offset uint32
 
 	offsetFile, err := os.Open(revOffsetFileName)
 	if err != nil {
@@ -84,17 +85,17 @@ func GetRevBlock(height int32, revOffsetFileName string) (
 	offsetFile.Seek(int64(8*height), 0)
 
 	// Read file and offset for the block
-	offsetFile.Read(datFile[:])
-	offsetFile.Read(offset[:])
+	binary.Read(offsetFile, binary.BigEndian, &datFile)
+	binary.Read(offsetFile, binary.BigEndian, &offset)
 
-	fileName := fmt.Sprintf("rev%05d.dat", int(BtU32(datFile[:])))
+	fileName := fmt.Sprintf("rev%05d.dat", int(datFile))
 
 	f, err := os.Open(fileName)
 	if err != nil {
 		return rBlock, err
 	}
 	// +8 skips the 8 bytes of magicbytes and load size
-	f.Seek(int64(BtU32(offset[:])+8), 0)
+	f.Seek(int64(offset+8), 0)
 
 	err = rBlock.Deserialize(f)
 	if err != nil {
@@ -240,26 +241,26 @@ func writeOffset(fileNum uint32, offsetFile *os.File) error {
 		}
 
 		// read the 4 byte size of the load of the block
-		var size [4]byte
-		_, err = f.Read(size[:])
+		var size uint32
+		err = binary.Read(f, binary.LittleEndian, &size)
 		if err != nil {
 			return err
 		}
 
 		// Write the .dat file name and the
 		// offset the block can be found at
-		_, err = offsetFile.Write(U32tB(fileNum))
+		err = binary.Write(offsetFile, binary.BigEndian, fileNum)
 		if err != nil {
 			return err
 		}
-		_, err = offsetFile.Write(U32tB(offset))
+		err = binary.Write(offsetFile, binary.BigEndian, offset)
 		if err != nil {
 			return err
 		}
 
 		// offset for the next block from the current position
 		// skip the 32 bytes of double sha hash of the rev block
-		loc, err = f.Seek(int64(LBtU32(size[:]))+32, 1)
+		loc, err = f.Seek(int64(size)+32, 1)
 		if err != nil {
 			return err
 		}

--- a/util/ttl/ttl.go
+++ b/util/ttl/ttl.go
@@ -1,6 +1,7 @@
 package ttl
 
 import (
+	"encoding/binary"
 	"fmt"
 	"sync"
 
@@ -30,8 +31,13 @@ func WriteBlock(bnr util.BlockAndRev,
 			if blockindex > 0 { // skip coinbase "spend"
 				opString := in.PreviousOutPoint.String()
 				h := util.HashFromString(opString)
-				blockBatch.Put(h[:], util.U32tB(uint32(bnr.Height+1))) // why +1??
+				heightBytes := make([]byte, 4)
+				binary.BigEndian.PutUint32(
+					heightBytes,
+					uint32(bnr.Height+1), // why +1??
+				)
 				// TODO ^^^^^ yeah why
+				blockBatch.Put(h[:], heightBytes)
 			}
 		}
 	}

--- a/util/utils.go
+++ b/util/utils.go
@@ -62,9 +62,10 @@ func CheckNet(net wire.BitcoinNet) {
 	var magicbytes [4]byte
 	f.Read(magicbytes[:])
 
-	bytesToMatch := U32tLB(uint32(net))
+	var bytesToMatch [4]byte
+	binary.LittleEndian.PutUint32(bytesToMatch[:], uint32(net))
 
-	if bytes.Compare(magicbytes[:], bytesToMatch) != 0 {
+	if bytes.Compare(magicbytes[:], bytesToMatch[:]) != 0 {
 		switch net {
 		case wire.TestNet3:
 			fmt.Println("Option -net=testnet given but .dat file is NOT a testnet file.")
@@ -285,7 +286,7 @@ func GetUDataFromFile(tipnum int32) (ud UData, err error) {
 	}
 
 	// +8 skips the 8 bytes of magicbytes and load size
-	// proofFile.Seek(int64(BtU32(offset[:])+8), 0)
+	// proofFile.Seek(int64(binary.BigEndian.Uint32(offset[:])+8), 0)
 	ubytes := make([]byte, size)
 
 	_, err = proofFile.Read(ubytes)
@@ -466,104 +467,6 @@ func PopPrefixLen16(b []byte) ([]byte, []byte, error) {
 		return nil, nil, fmt.Errorf("Prefixed %d but payload %d left", l)
 	}
 	return payload[:l], payload[l:], nil
-}
-
-// U32tB converts uint32 to 4 bytes.  Always works.
-func U32tB(i uint32) []byte {
-	var buf bytes.Buffer
-	binary.Write(&buf, binary.BigEndian, i)
-	return buf.Bytes()
-}
-
-// TODO make actual error return here
-// 4 byte Big Endian slice to uint32.  Returns ffffffff if something doesn't work.
-func BtU32(b []byte) uint32 {
-	if len(b) != 4 {
-		fmt.Printf("Got %x to BtU32 (%d bytes)\n", b, len(b))
-		return 0xffffffff
-	}
-	var i uint32
-	buf := bytes.NewBuffer(b)
-	binary.Read(buf, binary.BigEndian, &i)
-	return i
-}
-
-// int32 to 4 bytes (Big Endian).  Always works.
-func I32tB(i int32) []byte {
-	var buf bytes.Buffer
-	binary.Write(&buf, binary.BigEndian, i)
-	return buf.Bytes()
-}
-
-// TODO make actual error return here
-// 4 byte Big Endian slice to uint32.  Returns ffffffff if something doesn't work.
-func BtI32(b []byte) int32 {
-	if len(b) != 4 {
-		fmt.Printf("Got %x to ItU32 (%d bytes)\n", b, len(b))
-		return -0x7fffffff
-	}
-	var i int32
-	buf := bytes.NewBuffer(b)
-	binary.Read(buf, binary.BigEndian, &i)
-	return i
-}
-
-// uint32 to 4 bytes (Little Endian).  Always works.
-func U32tLB(i uint32) []byte {
-	b := make([]byte, 4)
-	binary.LittleEndian.PutUint32(b, i)
-	return b
-}
-
-// Converts 4 byte Little Endian slices to uint32.
-// Returns ffffffff if something doesn't work.
-func LBtU32(b []byte) uint32 {
-	if len(b) != 4 {
-		fmt.Printf("Got %x to LBtU32 (%d bytes)\n", b, len(b))
-		return 0xffffffff
-	}
-	var i uint32
-	buf := bytes.NewBuffer(b)
-	binary.Read(buf, binary.LittleEndian, &i)
-	return i
-}
-
-// BtU64 : 8 bytes to uint64.  returns ffff. if it doesn't work.
-func BtU64(b []byte) uint64 {
-	if len(b) != 8 {
-		fmt.Printf("Got %x to BtU64 (%d bytes)\n", b, len(b))
-		return 0xffffffffffffffff
-	}
-	var i uint64
-	buf := bytes.NewBuffer(b)
-	binary.Read(buf, binary.BigEndian, &i)
-	return i
-}
-
-// U64tB : uint64 to 8 bytes.  Always works.
-func U64tB(i uint64) []byte {
-	var buf bytes.Buffer
-	binary.Write(&buf, binary.BigEndian, i)
-	return buf.Bytes()
-}
-
-// BtI64 : 8 bytes to int64.  returns ffff. if it doesn't work.
-func BtI64(b []byte) int64 {
-	if len(b) != 8 {
-		fmt.Printf("Got %x to BtI64 (%d bytes)\n", b, len(b))
-		return -0x7fffffffffffffff
-	}
-	var i int64
-	buf := bytes.NewBuffer(b)
-	binary.Read(buf, binary.BigEndian, &i)
-	return i
-}
-
-// I64tB : int64 to 8 bytes.  Always works.
-func I64tB(i int64) []byte {
-	var buf bytes.Buffer
-	binary.Write(&buf, binary.BigEndian, i)
-	return buf.Bytes()
 }
 
 // CheckMagicByte checks for the Bitcoin magic bytes.


### PR DESCRIPTION
In an effort to reduce the util code...
The std library has all the functionality needed to convert integers to bytes and vice versa.

* In some cases this gets rid of the extra allocation, when converting to bytes.
* makes the code more readable (at least in my opinion)
