### PR TITLE
updateDirt maintains sortedness

### DIFF
--- a/accumulator/forest.go
+++ b/accumulator/forest.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"os"
+	"sort"
 	"time"
 )
 
@@ -187,10 +188,15 @@ func updateDirt(hashDirt []uint64, swapRow []arrow, numLeaves uint64, rows uint8
 			continue
 		}
 		prevHash = hashDest
-		if len(nextHashDirt) == 0 ||
-			(nextHashDirt[len(nextHashDirt)-1] != hashDest) {
-			// skip if already on end of slice. redundant?
-			nextHashDirt = append(nextHashDirt, hashDest)
+		i := sort.Search(len(nextHashDirt), func(i int) bool {
+			return nextHashDirt[i] >= hashDest
+		})
+		if i >= len(nextHashDirt) || nextHashDirt[i] != hashDest {
+			// hashDest was not in the list, and i is where
+			// it should be inserted
+			nextHashDirt = append(nextHashDirt, 0)
+			copy(nextHashDirt[i+1:], nextHashDirt[i:])
+			nextHashDirt[i] = hashDest
 		}
 	}
 	return nextHashDirt


### PR DESCRIPTION
Before this commit, updateDirt would return an unsorted slice,
which would then be passed back into updateDirt. Then,
dedupeSwapDirt would be called with its invariant violated.
So instead of the half-hearted checking of the last element,
we simply do a binary search (cheap) and insert the element
where it should be. No special treating of the last element.