### PR TITLE
bridgenode: Dont start the blockServer if genproofs was paused

### DIFF
--- a/bridgenode/genproofs.go
+++ b/bridgenode/genproofs.go
@@ -147,6 +147,13 @@ func BuildProofs(
 
 	fmt.Println("Done writing")
 
+	if stop {
+		// genproofs was paused.
+		// Tell stopBuildProofs that it's ok to exit
+		haltAccept <- true
+		return nil
+	}
+
 	// should be a goroutine..?  isn't right now
 	blockServer(knownTipHeight, haltRequest, haltAccept)
 


### PR DESCRIPTION
Fixes the problem mentioned here: https://github.com/mit-dci/utreexo/pull/144#issuecomment-640761200