### PR TITLE
accumulator: Add a cache for disk forest data

### DIFF
--- a/accumulator/forest.go
+++ b/accumulator/forest.go
@@ -111,10 +111,7 @@ func NewForest(forestFile *os.File) *Forest {
 		d := new(diskForestData)
 		d.f = forestFile
 		f.data = d
-		d.cache = diskForestCache{
-			Size: 1 << 11,
-			data: make(map[uint64]Hash),
-		}
+		d.cache = newDiskForestCache(24)
 	}
 
 	f.data.resize(1)
@@ -551,6 +548,7 @@ func RestoreForest(miscForestFile *os.File, forestFile *os.File) (*Forest, error
 		d := new(diskForestData)
 		d.f = forestFile
 		f.data = d
+		d.cache = newDiskForestCache(24)
 	}
 	f.positionMap = make(map[MiniHash]uint64)
 

--- a/accumulator/forest.go
+++ b/accumulator/forest.go
@@ -111,6 +111,10 @@ func NewForest(forestFile *os.File) *Forest {
 		d := new(diskForestData)
 		d.f = forestFile
 		f.data = d
+		d.cache = diskForestCache{
+			Size: 1 << 16, // 2^16 leaves
+			data: make(map[uint64]Hash),
+		}
 	}
 
 	f.data.resize(1)
@@ -579,6 +583,8 @@ func RestoreForest(miscForestFile *os.File, forestFile *os.File) (*Forest, error
 	fmt.Println("Forest rows:", f.rows)
 	fmt.Println("Done restoring forest")
 
+	f.data.size()
+
 	return f, nil
 }
 
@@ -606,6 +612,8 @@ func (f *Forest) WriteForest(miscForestFile *os.File) error {
 	if err != nil {
 		return err
 	}
+
+	f.data.close()
 
 	return nil
 }

--- a/accumulator/forest.go
+++ b/accumulator/forest.go
@@ -111,7 +111,7 @@ func NewForest(forestFile *os.File) *Forest {
 		d := new(diskForestData)
 		d.f = forestFile
 		f.data = d
-		d.cache = newDiskForestCache(24)
+		d.cache = newDiskForestCache(16)
 	}
 
 	f.data.resize(1)

--- a/accumulator/forest.go
+++ b/accumulator/forest.go
@@ -108,10 +108,9 @@ func NewForest(forestFile *os.File) *Forest {
 		f.data = new(ramForestData)
 	} else {
 		// for on-disk
-		d := new(cacheForestData)
+		d := new(diskForestData)
 		d.f = forestFile
 		f.data = d
-		d.cache = newDiskForestCache(16)
 	}
 
 	f.data.resize(1)
@@ -545,10 +544,9 @@ func RestoreForest(miscForestFile *os.File, forestFile *os.File) (*Forest, error
 		f.data = new(ramForestData)
 	} else {
 		// for on-disk
-		d := new(cacheForestData)
+		d := new(diskForestData)
 		d.f = forestFile
 		f.data = d
-		d.cache = newDiskForestCache(24)
 	}
 	f.positionMap = make(map[MiniHash]uint64)
 
@@ -581,6 +579,8 @@ func RestoreForest(miscForestFile *os.File, forestFile *os.File) (*Forest, error
 	fmt.Println("Forest rows:", f.rows)
 	fmt.Println("Done restoring forest")
 
+	// for cacheForestData the `hashCount` field gets
+	// set throught the size() call.
 	f.data.size()
 
 	return f, nil
@@ -638,7 +638,6 @@ func (f *Forest) Stats() string {
 	s += fmt.Sprintf("\thashT: %.2f remT: %.2f (of which MST %.2f) proveT: %.2f",
 		f.TimeInHash.Seconds(), f.TimeRem.Seconds(), f.TimeMST.Seconds(),
 		f.TimeInProve.Seconds())
-
 	return s
 }
 

--- a/accumulator/forest.go
+++ b/accumulator/forest.go
@@ -639,7 +639,6 @@ func (f *Forest) Stats() string {
 		f.TimeInHash.Seconds(), f.TimeRem.Seconds(), f.TimeMST.Seconds(),
 		f.TimeInProve.Seconds())
 
-	f.data.bench()
 	return s
 }
 

--- a/accumulator/forest.go
+++ b/accumulator/forest.go
@@ -112,7 +112,7 @@ func NewForest(forestFile *os.File) *Forest {
 		d.f = forestFile
 		f.data = d
 		d.cache = diskForestCache{
-			Size: 1 << 16, // 2^16 leaves
+			Size: 1 << 11,
 			data: make(map[uint64]Hash),
 		}
 	}

--- a/accumulator/forest.go
+++ b/accumulator/forest.go
@@ -108,7 +108,7 @@ func NewForest(forestFile *os.File) *Forest {
 		f.data = new(ramForestData)
 	} else {
 		// for on-disk
-		d := new(diskForestData)
+		d := new(cacheForestData)
 		d.f = forestFile
 		f.data = d
 		d.cache = newDiskForestCache(16)
@@ -545,7 +545,7 @@ func RestoreForest(miscForestFile *os.File, forestFile *os.File) (*Forest, error
 		f.data = new(ramForestData)
 	} else {
 		// for on-disk
-		d := new(diskForestData)
+		d := new(cacheForestData)
 		d.f = forestFile
 		f.data = d
 		d.cache = newDiskForestCache(24)
@@ -638,6 +638,8 @@ func (f *Forest) Stats() string {
 	s += fmt.Sprintf("\thashT: %.2f remT: %.2f (of which MST %.2f) proveT: %.2f",
 		f.TimeInHash.Seconds(), f.TimeRem.Seconds(), f.TimeMST.Seconds(),
 		f.TimeInProve.Seconds())
+
+	f.data.bench()
 	return s
 }
 

--- a/accumulator/forestdata.go
+++ b/accumulator/forestdata.go
@@ -88,6 +88,7 @@ type diskForestCache struct {
 	// The cache stores the forest data which is most frequently changed.
 	// Based on the ttl distribution of bitcoin utxos.
 	// (see figure 2 in the paper)
+	// TODO: convert to slice
 	data map[uint64]Hash
 }
 
@@ -373,7 +374,7 @@ func (d *diskForestData) readRange(
 				fmt.Printf("\treadRange WARNING!! read pos %d len %d %s\n (while populating cache)",
 					diskPosition, diskOverlap, err.Error())
 			}
-			d.diskReads += uint64(missBatchSize)
+			d.diskReads++
 
 			for j := uint64(0); j < uint64(missBatchSize); j++ {
 				copy(cacheHashes[batchPosition+j][:], missBatch[:j*leafSize])
@@ -394,7 +395,7 @@ func (d *diskForestData) readRange(
 		fmt.Printf("\treadRange WARNING!! read pos %d len %d %s\n",
 			diskPosition, diskOverlap, err.Error())
 	}
-	d.diskReads += diskOverlap
+	d.diskReads++
 
 	// convert diskRange to diskHashes
 	// TODO: this is ugly. we have 2 copies of the diskHashes in memory.
@@ -425,7 +426,7 @@ func (d *diskForestData) writeRange(
 		fmt.Printf("\twriteRange WARNING!! read pos %d len %d %s\n",
 			diskPosition, diskOverlap, err.Error())
 	}
-	d.diskWrites += diskOverlap
+	d.diskWrites++
 
 	// write cache hashes.
 	d.cache.rangeSet(

--- a/accumulator/forestdata.go
+++ b/accumulator/forestdata.go
@@ -3,22 +3,7 @@ package accumulator
 import (
 	"fmt"
 	"os"
-	"time"
 )
-
-var benchmarkFile *os.File
-var startTime time.Time
-
-func init() {
-	// open benchmark files
-	var err error
-	benchmarkFile, err = os.OpenFile("./benchmarks.csv", os.O_CREATE|os.O_RDWR, 0600)
-	if err != nil {
-		panic(err)
-	}
-	benchmarkFile.WriteString("timeSinceStart,forestSize,reads,writes,readTime,avgReadTime,writeTime,avgWriteTime,swapTime,avgSwapTime,cacheReads,cacheWrites,cacheMisses\n")
-	startTime = time.Now()
-}
 
 // leafSize is a [32]byte hash (sha256).
 // Length is always 32.
@@ -34,26 +19,12 @@ type ForestData interface {
 	size() uint64
 	resize(newSize uint64) // make it have a new size (bigger)
 	close()
-	bench()
 }
 
 // ********************************************* forest in ram
 
 type ramForestData struct {
 	m []Hash
-
-	hashCount uint64
-
-	diskReads  uint64
-	diskWrites uint64
-
-	readTime  time.Duration
-	writeTime time.Duration
-	swapTime  time.Duration
-
-	reads  uint64
-	writes uint64
-	swaps  uint64
 }
 
 // TODO it reads a lot of empty locations which can't be good
@@ -64,11 +35,7 @@ func (r *ramForestData) read(pos uint64) Hash {
 	// if r.m[pos] == empty {
 	// 	fmt.Printf("\tuseless read empty at pos %d\n", pos)
 	// }
-	start := time.Now()
-	h := r.m[pos]
-	r.readTime += time.Since(start)
-	r.reads++
-	return h
+	return r.m[pos]
 }
 
 // writeHash writes a hash.  Don't go out of bounds.
@@ -76,10 +43,7 @@ func (r *ramForestData) write(pos uint64, h Hash) {
 	// if h == empty {
 	// 	fmt.Printf("\tWARNING!! write empty at pos %d\n", pos)
 	// }
-	start := time.Now()
 	r.m[pos] = h
-	r.writeTime += time.Since(start)
-	r.writes++
 }
 
 // TODO there's lots of empty writes as well, mostly in resize?  Anyway could
@@ -93,15 +57,11 @@ func (r *ramForestData) swapHash(a, b uint64) {
 // swapHashRange swaps 2 continuous ranges of hashes.  Don't go out of bounds.
 // could be sped up if you're ok with using more ram.
 func (r *ramForestData) swapHashRange(a, b, w uint64) {
-	start := time.Now()
 	// fmt.Printf("swaprange %d %d %d\t", a, b, w)
 	for i := uint64(0); i < w; i++ {
 		r.m[a+i], r.m[b+i] = r.m[b+i], r.m[a+i]
 		// fmt.Printf("swapped %d %d\t", a+i, b+i)
 	}
-
-	r.swapTime += time.Since(start)
-	r.swaps++
 }
 
 // size gives you the size of the forest
@@ -112,59 +72,33 @@ func (r *ramForestData) size() uint64 {
 // resize makes the forest bigger (never gets smaller so don't try)
 func (r *ramForestData) resize(newSize uint64) {
 	r.m = append(r.m, make([]Hash, newSize-r.size())...)
-	r.hashCount = newSize
 }
 
 func (r *ramForestData) close() {
 	// nothing to do here fro a ram forest.
 }
 
-func (r *ramForestData) bench() {
-	benchmarkFile.WriteString(fmt.Sprintf("%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,,,\n",
-		time.Since(startTime), r.hashCount, r.reads, r.writes,
-		r.readTime, r.readTime/time.Duration(r.reads+1), r.writeTime, r.writeTime/time.Duration(r.writes+1), r.swapTime, r.swapTime/time.Duration(r.swaps+1)))
-}
-
 // ********************************************* forest on disk
 type diskForestData struct {
 	f *os.File
-
-	hashCount uint64
-
-	diskReads  uint64
-	diskWrites uint64
-
-	readTime  time.Duration
-	writeTime time.Duration
-	swapTime  time.Duration
-
-	reads  uint64
-	writes uint64
-	swaps  uint64
 }
 
 // read ignores errors. Probably get an empty hash if it doesn't work
 func (d *diskForestData) read(pos uint64) Hash {
-	start := time.Now()
 	var h Hash
 	_, err := d.f.ReadAt(h[:], int64(pos*leafSize))
 	if err != nil {
 		fmt.Printf("\tWARNING!! read %x pos %d %s\n", h, pos, err.Error())
 	}
-	d.readTime += time.Since(start)
-	d.reads++
 	return h
 }
 
 // writeHash writes a hash.  Don't go out of bounds.
 func (d *diskForestData) write(pos uint64, h Hash) {
-	start := time.Now()
 	_, err := d.f.WriteAt(h[:], int64(pos*leafSize))
 	if err != nil {
 		fmt.Printf("\tWARNING!! write pos %d %s\n", pos, err.Error())
 	}
-	d.writeTime += time.Since(start)
-	d.writes++
 }
 
 // swapHash swaps 2 hashes.  Don't go out of bounds.
@@ -181,7 +115,6 @@ func (d *diskForestData) swapHash(a, b uint64) {
 // depends if you count seeking from b-end to b-start as a seek. or if you have
 // like read & replace as one operation or something.
 func (d *diskForestData) swapHashRange(a, b, w uint64) {
-	start := time.Now()
 	arange := make([]byte, 32*w)
 	brange := make([]byte, 32*w)
 	_, err := d.f.ReadAt(arange, int64(a*leafSize)) // read at a
@@ -204,8 +137,6 @@ func (d *diskForestData) swapHashRange(a, b, w uint64) {
 		fmt.Printf("\tshr WARNING!! write pos %d len %d %s\n",
 			a*leafSize, w, err.Error())
 	}
-	d.swapTime += time.Since(start)
-	d.swaps++
 }
 
 // size gives you the size of the forest
@@ -226,12 +157,8 @@ func (d *diskForestData) resize(newSize uint64) {
 	}
 }
 
-func (d *diskForestData) close() {}
-
-func (d *diskForestData) bench() {
-	benchmarkFile.WriteString(fmt.Sprintf("%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,,,\n",
-		time.Since(startTime), d.hashCount, d.reads, d.writes,
-		d.readTime, d.readTime/time.Duration(d.reads+1), d.writeTime, d.writeTime/time.Duration(d.writes+1), d.swapTime, d.swapTime/time.Duration(d.swaps+1)))
+func (d *diskForestData) close() {
+	// nothing todo for diskForestData
 }
 
 // ********************************************* forest on disk with cache
@@ -275,22 +202,6 @@ type cacheForestData struct {
 	hashCount uint64
 
 	cache *diskForestCache
-
-	// for benchmarks:
-	cacheReads  uint64
-	cacheWrites uint64
-	cacheMisses uint64
-
-	diskReads  uint64
-	diskWrites uint64
-
-	readTime  time.Duration
-	writeTime time.Duration
-	swapTime  time.Duration
-
-	reads  uint64
-	writes uint64
-	swaps  uint64
 }
 
 // Calculates the overlap of a range (start, start+r) with the cache.
@@ -465,7 +376,6 @@ func (cache *diskForestCache) flush(hashCount uint64) []cacheRange {
 
 // read ignores errors. Probably get an empty hash if it doesn't work
 func (d *cacheForestData) read(pos uint64) Hash {
-	start := time.Now()
 	var h Hash
 	inCache, cachePos := d.cache.includes(pos, d.hashCount)
 	cacheMissed := false
@@ -475,14 +385,10 @@ func (d *cacheForestData) read(pos uint64) Hash {
 		h, ok := d.cache.get(cachePos)
 		if ok {
 			// The cache did hold the value at `pos`.
-			d.cacheReads++
-			d.readTime += time.Since(start)
-			d.reads++
 			return h
 		}
 		// The cache did not hold the value at `pos`.
 		cacheMissed = true
-		d.cacheMisses++
 	}
 
 	// Read `pos` from disk.
@@ -490,7 +396,6 @@ func (d *cacheForestData) read(pos uint64) Hash {
 	if err != nil {
 		fmt.Printf("\tWARNING!! read %x pos %d %s\n", h, pos, err.Error())
 	}
-	d.diskReads++
 
 	if cacheMissed {
 		// Populate the cache with the value read from disk.
@@ -498,28 +403,20 @@ func (d *cacheForestData) read(pos uint64) Hash {
 		// assuming the size of the forest doesn't change.
 		// This is how the cache gets restored when the forest is restored from disk.
 		d.cache.set(cachePos, h[:])
-		d.cacheWrites++
 	}
 
 	// `h` now holds the hash at `pos`, either read slowly from the disk
 	// or fast from the cache.
-	d.readTime += time.Since(start)
-	d.reads++
 	return h
 }
 
 // writeHash writes a hash.  Don't go out of bounds.
 func (d *cacheForestData) write(pos uint64, h Hash) {
-	start := time.Now()
 	inCache, cachePos := d.cache.includes(pos, d.hashCount)
 
 	// Write `h` to `pos` in the cache if `pos` should be included in the cache.
 	if inCache {
 		d.cache.set(cachePos, h[:])
-		d.cacheWrites++
-
-		d.writeTime += time.Since(start)
-		d.writes++
 		return
 	}
 
@@ -528,10 +425,6 @@ func (d *cacheForestData) write(pos uint64, h Hash) {
 	if err != nil {
 		fmt.Printf("\tWARNING!! write pos %d %s\n", pos, err.Error())
 	}
-	d.diskWrites++
-
-	d.writeTime += time.Since(start)
-	d.writes++
 }
 
 // swapHash swaps 2 hashes.  Don't go out of bounds.
@@ -563,7 +456,6 @@ func (d *cacheForestData) readRange(
 			if err != nil {
 				fmt.Printf("\tWARNING!! read pos %d %s\n", start, err.Error())
 			}
-			d.diskReads++
 		}
 	}
 
@@ -605,13 +497,10 @@ func (d *cacheForestData) writeRange(
 // depends if you count seeking from b-end to b-start as a seek. or if you have
 // like read & replace as one operation or something.
 func (d *cacheForestData) swapHashRange(a, b, w uint64) {
-	start := time.Now()
 	hashesA := d.readRange(a, w)
 	hashesB := d.readRange(b, w)
 	d.writeRange(b, w, hashesA)
 	d.writeRange(a, w, hashesB)
-	d.swapTime += time.Since(start)
-	d.swaps++
 }
 
 // size gives you the size of the forest
@@ -627,10 +516,6 @@ func (d *cacheForestData) size() uint64 {
 
 // resize makes the forest bigger (never gets smaller so don't try)
 func (d *cacheForestData) resize(newSize uint64) {
-	fmt.Printf("forest data cache benchmarks:"+
-		"cacheReads: %d, cacheWrites: %d, cacheMisses: %d, diskReads: %d, diskWrites: %d, hashCount: %d, readTime: %v(%v), writeTime: %v(%v), swapTime: %v(%v)\n",
-		d.cacheReads, d.cacheWrites, d.cacheMisses, d.diskReads, d.diskWrites, d.hashCount,
-		d.readTime, d.readTime/time.Duration(d.reads+1), d.writeTime, d.writeTime/time.Duration(d.writes+1), d.swapTime, d.swapTime/time.Duration(d.swaps+1))
 	// reset benchmark stats
 	cacheRanges := d.cache.flush(d.hashCount)
 	err := d.f.Truncate(int64(newSize * leafSize))
@@ -649,7 +534,6 @@ func (d *cacheForestData) resize(newSize uint64) {
 		if err != nil {
 			fmt.Printf("\tWARNING!! write pos %d %s\n", r.start, err.Error())
 		}
-		d.diskWrites++
 	}
 }
 
@@ -666,18 +550,5 @@ func (d *cacheForestData) close() {
 		if err != nil {
 			fmt.Printf("\tWARNING!! write pos %d %s\n", r.start, err.Error())
 		}
-		d.diskWrites++
 	}
-
-	fmt.Printf("forest data cache benchmarks:"+
-		"cacheReads: %d, cacheWrites: %d, cacheMisses: %d, diskReads: %d, diskWrites: %d, hashCount: %d\n",
-		d.cacheReads, d.cacheWrites, d.cacheMisses, d.diskReads, d.diskWrites, d.hashCount)
-	benchmarkFile.Close()
-}
-
-func (d *cacheForestData) bench() {
-	benchmarkFile.WriteString(fmt.Sprintf("%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n",
-		time.Since(startTime), d.hashCount, d.reads, d.writes,
-		d.readTime, d.readTime/time.Duration(d.reads+1), d.writeTime, d.writeTime/time.Duration(d.writes+1),
-		d.swapTime, d.swapTime/time.Duration(d.swaps+1), d.cacheReads, d.cacheWrites, d.cacheMisses))
 }

--- a/accumulator/forestdata.go
+++ b/accumulator/forestdata.go
@@ -1,8 +1,10 @@
 package accumulator
 
 import (
+	"bytes"
 	"fmt"
 	"os"
+	"sort"
 )
 
 // leafSize is a [32]byte hash (sha256).
@@ -18,6 +20,7 @@ type ForestData interface {
 	swapHashRange(a, b, w uint64)
 	size() uint64
 	resize(newSize uint64) // make it have a new size (bigger)
+	close()
 }
 
 // ********************************************* forest in ram
@@ -74,27 +77,255 @@ func (r *ramForestData) resize(newSize uint64) {
 	r.m = append(r.m, make([]Hash, newSize-r.size())...)
 }
 
+func (r *ramForestData) close() {
+	// nothing to do here fro a ram forest.
+}
+
 // ********************************************* forest on disk
+type diskForestCache struct {
+	// The number of leaves contained in the cached part of the forest.
+	Size uint64
+	// The cache stores the forest data which is most frequently changed.
+	// Based on the ttl distribution of bitcoin utxos.
+	// (see figure 2 in the paper)
+	data map[uint64]Hash
+}
+
+type cacheEntry struct {
+	position uint64
+	hash     Hash
+}
+
 type diskForestData struct {
 	f *os.File
+	// stores the size of the forest (the number of hashes stored).
+	// gets updated on every size()/resize() call.
+	hashCount uint64
+
+	cache diskForestCache
+
+	// for benchmarks:
+	cacheReads  uint64
+	cacheWrites uint64
+	cacheMisses uint64
+
+	diskReads  uint64
+	diskWrites uint64
+}
+
+// Calculates the overlap of a range (start, start+r) with the cache.
+// returns the amount of hashes of that range that are included in the cache.
+func (cache diskForestCache) rangeOverlap(start, r, hashCount uint64) uint64 {
+	row := uint8(0)
+	rowOffset := uint64(0)
+
+	cacheSize := cache.Size
+	if cacheSize > hashCount {
+		cacheSize = hashCount >> 1
+	}
+
+	for hashesCachedOnRow := cacheSize; hashesCachedOnRow>>row != 0; {
+		totalHashesOnRow := hashCount >> (row + 1)
+		minPosition := rowOffset + (totalHashesOnRow - hashesCachedOnRow)
+		maxPosition := rowOffset + totalHashesOnRow
+
+		if start < minPosition &&
+			start+r >= minPosition {
+			return (start + r) - minPosition
+		}
+
+		if start >= minPosition && start <= maxPosition {
+			// The whole range lies with in the cache.
+			return r
+		}
+
+		row++
+		rowOffset += totalHashesOnRow
+	}
+
+	return 0
+}
+
+// Check if a position should be included in the cache based on `CacheSize`.
+// Goes through each forest row and checks if `pos` is in the cached portion of that row.
+func (cache diskForestCache) includes(pos uint64, hashCount uint64) bool {
+	row := uint8(0)
+	rowOffset := uint64(0)
+
+	cacheSize := cache.Size
+	if cacheSize > hashCount {
+		cacheSize = hashCount >> 1
+	}
+
+	for hashesCachedOnRow := cacheSize; hashesCachedOnRow>>row != 0; {
+		totalHashesOnRow := hashCount >> (row + 1)
+		minPosition := rowOffset + (totalHashesOnRow - hashesCachedOnRow)
+		maxPosition := rowOffset + totalHashesOnRow
+
+		if pos >= minPosition && pos <= maxPosition {
+			return true
+		}
+		row++
+		rowOffset += totalHashesOnRow
+	}
+
+	return false
+}
+
+// Get a hash from the cache.
+// Returns the hash found at pos and wether or not the cache was populated
+// for that position. If it wasn't populated it should be with the contents
+// from disk.
+func (cache diskForestCache) get(pos uint64) (Hash, bool) {
+	hash, ok := cache.data[pos]
+	if !ok {
+		// is hash==empty if ok==false?
+		return empty, ok
+	}
+
+	return hash, ok
+}
+
+func (cache diskForestCache) rangeGet(start uint64, r uint64) ([]Hash, []uint64) {
+	set := make([]Hash, r)
+	var misses []uint64
+	for i := uint64(0); i < r; i++ {
+		hash, ok := cache.get(start + i)
+		if !ok {
+			misses = append(misses, i)
+		}
+		set[i] = hash
+	}
+	return set, misses
+}
+
+// Set a position in the cache.
+// The previous value at that position is overwritten.
+// Will create an entry in the cache wether
+// or not it should actually be included.
+// Check inclusion first with `includes`.
+func (cache diskForestCache) set(pos uint64, hash Hash) {
+	cache.data[pos] = hash
+}
+
+func (cache diskForestCache) rangeSet(start uint64,
+	r uint64, hashes []Hash) {
+	if r != uint64(len(hashes)) {
+		panic(
+			fmt.Sprintf(
+				"rangeSet: range was %d but only %d hashes were given",
+				r, len(hashes),
+			),
+		)
+	}
+
+	for i := uint64(0); i < r; i++ {
+		cache.set(start+i, hashes[i])
+	}
+}
+
+// Deletes all cache entries and returns them.
+// Returned cache entries are sorted by their positions.
+func (cache diskForestCache) flush() []*cacheEntry {
+	cacheLength := len(cache.data)
+	entries := make([]*cacheEntry, cacheLength)
+	i := 0
+	for pos, hash := range cache.data {
+		entries[i] = &cacheEntry{
+			position: pos,
+			hash:     hash,
+		}
+		delete(cache.data, pos)
+		i++
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].position < entries[j].position
+	})
+
+	return entries
+}
+
+// Deletes entries with positions that should not be
+// in the cache after a resize.
+// Returns deleted cache entries.
+// Returned cache entries are sorted by their positions.
+func (cache diskForestCache) flushOldHashes(
+	newHashCount uint64) []*cacheEntry {
+	var entries []*cacheEntry
+	for pos, hash := range cache.data {
+		if cache.includes(pos, newHashCount) {
+			// Keep hashes in the cache that still are
+			// in the cache after a resize.
+			continue
+		}
+		entries = append(entries, &cacheEntry{
+			position: pos,
+			hash:     hash,
+		})
+		delete(cache.data, pos)
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].position < entries[j].position
+	})
+
+	return entries
 }
 
 // read ignores errors. Probably get an empty hash if it doesn't work
 func (d *diskForestData) read(pos uint64) Hash {
 	var h Hash
+	cacheMissed := false
+
+	// Read `pos` from cache if the cache should include it.
+	if d.cache.includes(pos, d.hashCount) {
+		h, ok := d.cache.get(pos)
+		if ok {
+			// The cache did hold the value at `pos`.
+			d.cacheReads++
+			return h
+		}
+		// The cache did not hold the value at `pos`.
+		cacheMissed = true
+		d.cacheMisses++
+	}
+
+	// Read `pos` from disk.
 	_, err := d.f.ReadAt(h[:], int64(pos*leafSize))
 	if err != nil {
 		fmt.Printf("\tWARNING!! read %x pos %d %s\n", h, pos, err.Error())
 	}
+	d.diskReads++
+
+	if cacheMissed {
+		// Populate the cache with the value read from disk.
+		// On the next read of `pos` it will be fetched from the cache,
+		// assuming the size of the forest doesn't change.
+		// This is how the cache gets restored when the forest is restored from disk.
+		d.cache.set(pos, h)
+	}
+
+	// `h` now holds the hash at `pos`, either read slowly from the disk
+	// or fast from the cache.
 	return h
 }
 
 // writeHash writes a hash.  Don't go out of bounds.
 func (d *diskForestData) write(pos uint64, h Hash) {
+	// Write `h` to `pos`in the cache if `pos` should be included in the cache.
+	if d.cache.includes(pos, d.hashCount) {
+		d.cache.set(pos, h)
+		d.cacheWrites++
+		return
+	}
+
+	// Write `h` to disk if it was not included in the cache.
 	_, err := d.f.WriteAt(h[:], int64(pos*leafSize))
 	if err != nil {
 		fmt.Printf("\tWARNING!! write pos %d %s\n", pos, err.Error())
 	}
+	d.diskWrites++
 }
 
 // swapHash swaps 2 hashes.  Don't go out of bounds.
@@ -105,34 +336,116 @@ func (d *diskForestData) swapHash(a, b uint64) {
 	d.write(b, ha)
 }
 
+func (d *diskForestData) readRange(
+	start, r uint64) (hashes []Hash) {
+	// The number of hashes from the range included in the cache.
+	cacheOverlap := d.cache.rangeOverlap(start, r, d.hashCount)
+	// The number of hashes from the range stored on disk.
+	diskOverlap := r - cacheOverlap
+	diskPosition := int64(start * leafSize)
+
+	// retrieve cache hashes.
+	cacheHashes, misses := d.cache.rangeGet(start+diskOverlap, cacheOverlap)
+	ok := len(misses) == 0
+	if ok {
+		d.cacheReads += cacheOverlap
+	} else {
+		// fetch misses from disk and populate cache.
+		d.cacheMisses += uint64(len(misses))
+		missBatchSize := 1
+		batchPosition := misses[0]
+		for i := uint64(0); i < uint64(len(misses)-1); i++ {
+			miss := misses[i]
+			nextMiss := misses[i+1]
+			if miss == nextMiss+1 {
+				// sequential misses can be batched.
+				missBatchSize++
+				continue
+			}
+
+			missBatch := make([]byte, missBatchSize*leafSize)
+			_, err := d.f.ReadAt(missBatch,
+				int64(uint64(diskPosition)+
+					diskOverlap*uint64(leafSize)+
+					batchPosition*uint64(leafSize)),
+			)
+			if err != nil {
+				fmt.Printf("\treadRange WARNING!! read pos %d len %d %s\n (while populating cache)",
+					diskPosition, diskOverlap, err.Error())
+			}
+			d.diskReads += uint64(missBatchSize)
+
+			for j := uint64(0); j < uint64(missBatchSize); j++ {
+				copy(cacheHashes[batchPosition+j][:], missBatch[:j*leafSize])
+				d.cache.set(start+diskOverlap+miss, cacheHashes[batchPosition+j])
+			}
+
+			missBatchSize = 1
+			batchPosition = nextMiss
+		}
+	}
+
+	// retrieve disk hashes.
+	hashes = make([]Hash, diskOverlap)
+	diskRange := make([]byte, leafSize*diskOverlap)
+
+	_, err := d.f.ReadAt(diskRange, diskPosition)
+	if err != nil {
+		fmt.Printf("\treadRange WARNING!! read pos %d len %d %s\n",
+			diskPosition, diskOverlap, err.Error())
+	}
+	d.diskReads += diskOverlap
+
+	// convert diskRange to diskHashes
+	// TODO: this is ugly. we have 2 copies of the diskHashes in memory.
+	for i := range hashes {
+		copy(hashes[i][:], diskRange[i*leafSize:(i*leafSize)+32])
+	}
+
+	hashes = append(hashes, cacheHashes...)
+
+	return
+}
+
+func (d *diskForestData) writeRange(
+	start, r uint64, hashes []Hash) {
+	cacheOverlap := d.cache.rangeOverlap(start, r, d.hashCount)
+	diskOverlap := r - cacheOverlap
+	hashIndex := uint64(0)
+
+	// write disk hashes.
+	var diskBuf bytes.Buffer
+	for ; hashIndex < diskOverlap; hashIndex++ {
+		diskBuf.Write(hashes[hashIndex][:])
+	}
+
+	diskPosition := int64(start * leafSize)
+	_, err := d.f.WriteAt(diskBuf.Bytes(), diskPosition) // write arange to b
+	if err != nil {
+		fmt.Printf("\twriteRange WARNING!! read pos %d len %d %s\n",
+			diskPosition, diskOverlap, err.Error())
+	}
+	d.diskWrites += diskOverlap
+
+	// write cache hashes.
+	d.cache.rangeSet(
+		start+diskOverlap,
+		cacheOverlap,
+		hashes[diskOverlap:],
+	)
+	d.cacheWrites += cacheOverlap
+}
+
 // swapHashRange swaps 2 continuous ranges of hashes.  Don't go out of bounds.
 // uses lots of ram to make only 3 disk seeks (depending on how you count? 4?)
 // seek to a start, read a, seek to b start, read b, write b, seek to a, write a
 // depends if you count seeking from b-end to b-start as a seek. or if you have
 // like read & replace as one operation or something.
 func (d *diskForestData) swapHashRange(a, b, w uint64) {
-	arange := make([]byte, 32*w)
-	brange := make([]byte, 32*w)
-	_, err := d.f.ReadAt(arange, int64(a*leafSize)) // read at a
-	if err != nil {
-		fmt.Printf("\tshr WARNING!! read pos %d len %d %s\n",
-			a*leafSize, w, err.Error())
-	}
-	_, err = d.f.ReadAt(brange, int64(b*leafSize)) // read at b
-	if err != nil {
-		fmt.Printf("\tshr WARNING!! read pos %d len %d %s\n",
-			b*leafSize, w, err.Error())
-	}
-	_, err = d.f.WriteAt(arange, int64(b*leafSize)) // write arange to b
-	if err != nil {
-		fmt.Printf("\tshr WARNING!! write pos %d len %d %s\n",
-			b*leafSize, w, err.Error())
-	}
-	_, err = d.f.WriteAt(brange, int64(a*leafSize)) // write brange to a
-	if err != nil {
-		fmt.Printf("\tshr WARNING!! write pos %d len %d %s\n",
-			a*leafSize, w, err.Error())
-	}
+	hashesA := d.readRange(a, w)
+	hashesB := d.readRange(b, w)
+	d.writeRange(b, w, hashesA)
+	d.writeRange(a, w, hashesB)
 }
 
 // size gives you the size of the forest
@@ -142,13 +455,36 @@ func (d *diskForestData) size() uint64 {
 		fmt.Printf("\tWARNING: %s. Returning 0", err.Error())
 		return 0
 	}
-	return uint64(s.Size() / leafSize)
+	d.hashCount = uint64(s.Size() / leafSize)
+	return d.hashCount
 }
 
 // resize makes the forest bigger (never gets smaller so don't try)
 func (d *diskForestData) resize(newSize uint64) {
+	fmt.Println("resize: ", newSize)
+	cacheEntries := d.cache.flushOldHashes(newSize)
 	err := d.f.Truncate(int64(newSize * leafSize))
 	if err != nil {
 		panic(err)
 	}
+	d.hashCount = newSize
+
+	// write cache entries to disk.
+	// TODO: batch write sequential entries.
+	for _, entry := range cacheEntries {
+		d.write(entry.position, entry.hash)
+	}
+}
+
+func (d *diskForestData) close() {
+	// flush the entire cache to disk.
+	cacheEntries := d.cache.flush()
+	// TODO: batch write sequential entries.
+	for _, entry := range cacheEntries {
+		d.write(entry.position, entry.hash)
+	}
+
+	fmt.Printf("forest data cache benchmarks:"+
+		"cacheReads: %d, cacheWrites: %d, cacheMisses: %d, diskReads: %d, diskWrites: %d, hashCount: %d\n",
+		d.cacheReads, d.cacheWrites, d.cacheMisses, d.diskReads, d.diskWrites, d.hashCount)
 }


### PR DESCRIPTION
Adds a new type `cacheForestData` that implements the `ForestData` interface. This type improves the performance of `diskForestData` by caching parts of the forest in ram.
The cache holds a certain number of trees of the full forest while the other trees are kept on disk, the trees kept in the cache are the smallest trees in the forest. The whole forest might be held in ram when the cache size allows it.

Usage:
```go
d := new(cacheForestData)
// 16 means that the 16 smallest trees will be cached.
// that's only about ~4MB, 17 would be ~8MB, 18 -> ~16MB, ..., 27 -> 8448MB, ...
d.cache = newDiskForestCache(16)
d.f = forestFile
```