### PR TITLE
offsetfile: Buffer the leveldb, reader, and writer for offestfile

### DIFF
--- a/bridgenode/offsetfile_test.go
+++ b/bridgenode/offsetfile_test.go
@@ -1,15 +1,44 @@
 package bridgenode
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
 
-	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/mit-dci/utreexo/util"
+	"github.com/syndtr/goleveldb/leveldb"
 )
+
+func BenchmarkBuildOffsetFile(b *testing.B) {
+	tmpDir, err := ioutil.TempDir("", "test")
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir) // clean up. Always runs
+
+	// grab the datadir for this system
+	// use testnet3
+	testnetDataDir := filepath.Join(util.GetBitcoinDataDir(), "testnet3/blocks")
+	tmpOffsetFile := filepath.Join(tmpDir, "offsetfile")
+	tmpLastOffsetHeightFile := filepath.Join(tmpDir, "loffsetfile")
+
+	db := OpenIndexFile(testnetDataDir)
+	defer db.Close()
+
+	hash, err := util.GenHashForNet(chaincfg.TestNet3Params)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	_, err = buildOffsetFile(testnetDataDir, *hash, tmpOffsetFile, tmpLastOffsetHeightFile)
+	if err != nil {
+		b.Fatal(err)
+	}
+}
 
 func TestBuildOffsetFile(t *testing.T) {
 	tmpDir, err := ioutil.TempDir("", "test")
@@ -20,9 +49,9 @@ func TestBuildOffsetFile(t *testing.T) {
 
 	// grab the datadir for this system
 	// use testnet3
-	testnetDataDir := filepath.Join(util.GetBitcoinDataDir(), "testnet3")
+	testnetDataDir := filepath.Join(util.GetBitcoinDataDir(), "testnet3/blocks")
 	// grab testnet3 hash
-	testnetHash, err := util.GenHashForNet(wire.TestNet3)
+	testnetHash, err := util.GenHashForNet(chaincfg.TestNet3Params)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -48,8 +77,8 @@ func TestBuildOffsetFile(t *testing.T) {
 		lastOffsetHeight, 1)
 
 	// Check that things in the offsetfile are correct
-	// 300,000 blocks is prob enough
-	for i := int32(1); i < 300000; i++ { // skip genesis
+	// 200,000 blocks is prob enough
+	for i := int32(1); i < 200000; i++ { // skip genesis
 		bnr := <-bnrChan
 
 		cbIdx := GetBlockIndexInfo(bnr.Blk.BlockHash(), lvdb)
@@ -67,8 +96,32 @@ func TestBuildOffsetFile(t *testing.T) {
 				i, len(bnr.Blk.Transactions), len(bnr.Rev.Txs))
 			t.Fatal(err)
 		}
-		if i%100000 == 0 {
+		if i%20000 == 0 {
 			fmt.Println("# of tested blocks: ", i)
 		}
 	}
+}
+
+// GetBlockIndexInfo returns a CBlockFileIndex based on the hash given as a key
+func GetBlockIndexInfo(h [32]byte, lvdb *leveldb.DB) CBlockFileIndex {
+	// 0x62 is hex representation of ascii 'b' (98), which is used
+	// appended to block keys in leveldb
+	lookup := append([]byte{0x62}, h[:]...)
+
+	value, err := lvdb.Get(lookup, nil)
+	if err == leveldb.ErrClosed { // Handle db closed err
+		panic(err)
+	}
+	// Sometimes there may be a block in blk that is not verified but is just sitting there
+	// Warn the user about it but ignore it since it doesn't effect the actual validation
+	if err != nil { // all other returned errors are from reading the db
+		str := fmt.Errorf("%s WARNING: A block in blk file exists without"+
+			"a corresponding rev block location. May be wasting disk space", err)
+		fmt.Println(str)
+	}
+
+	r := bytes.NewReader(value)
+	cbIdx := ReadCBlockFileIndex(r)
+
+	return cbIdx
 }

--- a/bridgenode/rev.go
+++ b/bridgenode/rev.go
@@ -12,6 +12,7 @@ import (
 	"github.com/mit-dci/utreexo/util"
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/opt"
+	dbutil "github.com/syndtr/goleveldb/leveldb/util"
 )
 
 // Wire Protocol version
@@ -23,6 +24,24 @@ const pver uint32 = 0
 // MaxMessagePayload is the maximum bytes a message can be regardless of other
 // individual limits imposed by messages themselves.
 const MaxMessagePayload = (1024 * 1024 * 32) // 32MB
+
+// RawHeaderData is used for blk*.dat offsetfile building
+// Used for ordering blocks as they aren't stored in order in the blk files.
+// Includes 32 bytes of sha256 hash along with other variables
+// needed for offsetfile building.
+type RawHeaderData struct {
+	// CurrentHeaderHash is the double hashed 32 byte header
+	CurrentHeaderHash [32]byte
+	// Prevhash is the 32 byte previous header included in the 80byte header.
+	// Needed for ordering
+	Prevhash [32]byte
+	// FileNum is the blk*.dat file number
+	FileNum [4]byte
+	// Offset is where it is in the .dat file.
+	Offset [4]byte
+	// revblock position
+	UndoPos uint32
+}
 
 // BlockReader is a wrapper around GetRawBlockFromFile so that the process
 // can be made into a goroutine. As long as it's running, it keeps sending
@@ -289,28 +308,25 @@ type CBlockFileIndex struct {
 	UndoPos uint32 // rev*.dat file offset
 }
 
-// GetBlockIndexInfo returns a
-func GetBlockIndexInfo(h [32]byte, lvdb *leveldb.DB) CBlockFileIndex {
-	// 0x62 is hex representation of ascii 'b' (98), which is used
-	// appended to block keys in leveldb
-	lookup := append([]byte{0x62}, h[:]...)
+// BufferDB buffers the leveldb key values into map in memory
+func BufferDB(lvdb *leveldb.DB) map[[32]byte]uint32 {
+	bufDB := make(map[[32]byte]uint32)
+	var header [32]byte
 
-	value, err := lvdb.Get(lookup, nil)
-	if err == leveldb.ErrClosed { // Handle db closed err
+	iter := lvdb.NewIterator(dbutil.BytesPrefix([]byte{0x62}), nil)
+	for iter.Next() {
+		copy(header[:], iter.Key()[1:])
+		cbIdx := ReadCBlockFileIndex(bytes.NewReader(iter.Value()))
+		bufDB[header] = cbIdx.UndoPos
+	}
+
+	iter.Release()
+	err := iter.Error()
+	if err != nil {
 		panic(err)
 	}
-	// Sometimes there may be a block in blk that is not verified but is just sitting there
-	// Warn the user about it but ignore it since it doesn't effect the actual validation
-	if err != nil { // all other returned errors are from reading the db
-		str := fmt.Errorf("%s WARNING: A block in blk file exists without"+
-			"a corresponding rev block location. May be wasting disk space", err)
-		fmt.Println(str)
-	}
 
-	r := bytes.NewReader(value)
-	cbIdx := ReadCBlockFileIndex(r)
-
-	return cbIdx
+	return bufDB
 }
 
 func ReadCBlockFileIndex(r io.ReadSeeker) (cbIdx CBlockFileIndex) {

--- a/util/types.go
+++ b/util/types.go
@@ -35,22 +35,6 @@ type zProofTx struct {
 	txIndex       int         // Position within a block or TxIndexUnknown
 }
 
-// RawHeaderData is used for blk*.dat offsetfile building
-// Used for ordering blocks as they aren't stored in order in the blk files.
-// Includes 32 bytes of sha256 hash along with other variables
-// needed for offsetfile building.
-type RawHeaderData struct {
-	// CurrentHeaderHash is the double hashed 32 byte header
-	CurrentHeaderHash [32]byte
-	// Prevhash is the 32 byte previous header included in the 80byte header.
-	// Needed for ordering
-	Prevhash [32]byte
-	// FileNum is the blk*.dat file number
-	FileNum [4]byte
-	// Offset is where it is in the .dat file.
-	Offset [4]byte
-}
-
 // UBlock is a regular block, with Udata stuck on
 type UBlock struct {
 	Block     wire.MsgBlock

--- a/util/utils.go
+++ b/util/utils.go
@@ -323,10 +323,10 @@ func PopPrefixLen16(b []byte) ([]byte, []byte, error) {
 // CheckMagicByte checks for the Bitcoin magic bytes.
 // returns false if it didn't read the Bitcoin magic bytes.
 // Checks only for testnet3 and mainnet
-func CheckMagicByte(bytesgiven [4]byte) bool {
-	if bytesgiven != [4]byte{0x0b, 0x11, 0x09, 0x07} && //testnet
-		bytesgiven != [4]byte{0xf9, 0xbe, 0xb4, 0xd9} && // mainnet
-		bytesgiven != [4]byte{0xfa, 0xbf, 0xb5, 0xda} { // regtest
+func CheckMagicByte(bytesgiven []byte) bool {
+	if bytes.Compare(bytesgiven, []byte{0x0b, 0x11, 0x09, 0x07}) != 0 && //testnet
+		bytes.Compare(bytesgiven, []byte{0xf9, 0xbe, 0xb4, 0xd9}) != 0 && // mainnet
+		bytes.Compare(bytesgiven, []byte{0xfa, 0xbf, 0xb5, 0xda}) != 0 { // regtest
 		fmt.Printf("got non magic bytes %x, finishing\n", bytesgiven)
 		return false
 	} else {


### PR DESCRIPTION
Offsetfile building but now with buffers. In my machine, sys and user time is 80% less but the wall clock is only showing 30% less time :/ I guess there's some serious disk io bottleneck going on that *could* be improved with more effort. Just not sure if it's worth the effort.

Benchmark added in offestfile_test.go and also fixes a test in offsetfile_test.go which was broken in master. We could also start to use the tests here...