### PR TITLE
bridgenode: Improve BlockAndRevReader performance

### DIFF
--- a/bridgenode/rev.go
+++ b/bridgenode/rev.go
@@ -64,7 +64,7 @@ func BlockAndRevReader(
 	}
 
 	for curHeight < maxHeight {
-		blocks, revs, err := GetRawBlocksFromDisk(curHeight, 1000, offsetFilePath, dataDir)
+		blocks, revs, err := GetRawBlocksFromDisk(curHeight, 100000, offsetFilePath, dataDir)
 		if err != nil {
 			fmt.Printf(err.Error())
 			// close(blockChan)

--- a/bridgenode/rev.go
+++ b/bridgenode/rev.go
@@ -64,7 +64,7 @@ func BlockAndRevReader(
 		offsetFilePath = cOffsetFile
 	}
 
-	for curHeight != maxHeight {
+	for curHeight < maxHeight {
 		blocks, revs, err := GetRawBlocksFromDisk(curHeight, 1000, offsetFilePath, dataDir)
 		if err != nil {
 			fmt.Printf(err.Error())
@@ -123,7 +123,7 @@ func GetRawBlocksFromDisk(startAt int32, count int32, offsetFileName string,
 		var datFileNumTmp uint32
 		err = binary.Read(offsetReader, binary.BigEndian, &datFileNumTmp)
 		if err != nil {
-			return
+			break
 		}
 		if offsetsRead > 0 && datFileNumTmp != datFileNum {
 			break
@@ -151,6 +151,10 @@ func GetRawBlocksFromDisk(startAt int32, count int32, offsetFileName string,
 		if revOffsets[offsetsRead] > maxRevOffset {
 			maxRevOffset = revOffsets[offsetsRead]
 		}
+	}
+
+	if offsetsRead == 0 {
+		return
 	}
 
 	blockFile, err := os.Open(filepath.Join(blockDir,


### PR DESCRIPTION
Problem: the `BlockAndRevReader` makes a ton of syscalls because it reads each block individually from the blk files.
Solution: read multiple blocks from the blk files at once.

pprof results:

Before: 
<img width="638" alt="Screenshot 2020-07-14 at 21 07 20" src="https://user-images.githubusercontent.com/8077169/87466252-3f315800-c616-11ea-9e48-762b4f2192c7.png">

After:
<img width="672" alt="Screenshot 2020-07-14 at 21 08 04" src="https://user-images.githubusercontent.com/8077169/87466279-49ebed00-c616-11ea-9b72-5fca0003fa98.png">
