### PR TITLE
Stop server from looking at the data it's serving

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ cmd/clair/clair
 cmd/simcmd/simcmd
 cmd/utreexoclient/utreexoclient
 cmd/utreexoserver/utreexoserver
+cmd/utreexoclient/pollardFile 

--- a/accumulator/batchproof.go
+++ b/accumulator/batchproof.go
@@ -22,7 +22,9 @@ func (bp *BatchProof) ToBytes() []byte {
 	// first write the number of targets (4 byte uint32)
 
 	numTargets := uint32(len(bp.Targets))
-
+	if numTargets == 0 {
+		return nil
+	}
 	err := binary.Write(&buf, binary.BigEndian, numTargets)
 	if err != nil {
 		fmt.Printf("huh %s\n", err.Error())
@@ -71,8 +73,14 @@ func (bp *BatchProof) ToString() string {
 func FromBytesBatchProof(b []byte) (BatchProof, error) {
 	var bp BatchProof
 
+	// if empty slice, return empty BatchProof with 0 targets
+	if len(b) == 0 {
+		return bp, nil
+	}
+	// otherwise, if there are less than 4 bytes we can't even see the number
+	// of targets so something is wrong
 	if len(b) < 4 {
-		return bp, fmt.Errorf("blockproof only %d bytes", len(b))
+		return bp, fmt.Errorf("batchproof only %d bytes", len(b))
 	}
 
 	buf := bytes.NewBuffer(b)

--- a/bridgenode/genproofs.go
+++ b/bridgenode/genproofs.go
@@ -44,7 +44,7 @@ func BuildProofs(
 		return err
 	}
 	// for testing only
-	knownTipHeight = 500
+	knownTipHeight = 50000
 
 	ttlpath := "utree/" + param.Name + "ttldb"
 	// Open leveldb
@@ -104,7 +104,6 @@ func BuildProofs(
 
 		// convert UData struct to bytes
 		b := ud.ToBytes()
-		fmt.Printf("height %d made %d byte ud %x\n", height, len(b), b)
 
 		// Add to WaitGroup and send data to channel to be written
 		// to disk

--- a/bridgenode/genproofs.go
+++ b/bridgenode/genproofs.go
@@ -43,6 +43,8 @@ func BuildProofs(
 		fmt.Printf("not in %s, specify alternate path with -datadir\n.", dataDir)
 		return err
 	}
+	// for testing only
+	knownTipHeight = 500
 
 	ttlpath := "utree/" + param.Name + "ttldb"
 	// Open leveldb
@@ -102,6 +104,7 @@ func BuildProofs(
 
 		// convert UData struct to bytes
 		b := ud.ToBytes()
+		fmt.Printf("height %d made %d byte ud %x\n", height, len(b), b)
 
 		// Add to WaitGroup and send data to channel to be written
 		// to disk

--- a/bridgenode/genproofs.go
+++ b/bridgenode/genproofs.go
@@ -44,7 +44,7 @@ func BuildProofs(
 		return err
 	}
 	// for testing only
-	knownTipHeight = 50000
+	// knownTipHeight = 200000
 
 	ttlpath := "utree/" + param.Name + "ttldb"
 	// Open leveldb

--- a/bridgenode/server.go
+++ b/bridgenode/server.go
@@ -76,7 +76,7 @@ func pushBlocks(c net.Conn, endHeight int32, blockDir string) {
 			fmt.Printf("pushBlocks GetUDataBytesFromFile %s\n", err.Error())
 			return
 		}
-		fmt.Printf("h %d read %d byte udb\n", curHeight, len(udb))
+		// fmt.Printf("h %d read %d byte udb\n", curHeight, len(udb))
 
 		blkbytes, err := GetBlockBytesFromFile(curHeight, util.OffsetFilePath, blockDir)
 		if err != nil {
@@ -98,12 +98,12 @@ func pushBlocks(c net.Conn, endHeight int32, blockDir string) {
 			fmt.Printf("pushBlocks binary.Write %s\n", err.Error())
 			return
 		}
-		n, err := c.Write(udb)
+		_, err = c.Write(udb)
 		if err != nil {
 			fmt.Printf("pushBlocks ubb write %s\n", err.Error())
 			return
 		}
-		fmt.Printf("wrote %d bytes udb\n", n)
+		// fmt.Printf("wrote %d bytes udb\n", n)
 	}
 	fmt.Printf("done pushing blocks to %s\n", c.RemoteAddr().String())
 	c.Close()

--- a/bridgenode/server.go
+++ b/bridgenode/server.go
@@ -71,25 +71,39 @@ func pushBlocks(c net.Conn, endHeight int32, blockDir string) {
 
 	for ; curHeight < endHeight; curHeight++ {
 		// fmt.Printf("push %d\n", curHeight)
-		ud, err := util.GetUDataFromFile(curHeight)
+		udb, err := util.GetUDataBytesFromFile(curHeight)
 		if err != nil {
-			fmt.Printf("pushBlocks GetUDataFromFile %s\n", err.Error())
+			fmt.Printf("pushBlocks GetUDataBytesFromFile %s\n", err.Error())
 			return
 		}
+		fmt.Printf("h %d read %d byte udb\n", curHeight, len(udb))
 
-		blk, _, err := GetRawBlockFromFile(curHeight, util.OffsetFilePath, blockDir)
+		blkbytes, err := GetBlockBytesFromFile(curHeight, util.OffsetFilePath, blockDir)
 		if err != nil {
 			fmt.Printf("pushBlocks GetRawBlockFromFile %s\n", err.Error())
 			return
 		}
 
-		// put proofs & block together, send that over
-		ub := util.UBlock{ExtraData: ud, Block: blk}
-		err = ub.Serialize(c)
+		// first send the block bytes
+		_, err = c.Write(blkbytes)
 		if err != nil {
-			fmt.Printf("pushBlocks ub.Serialize %s\n", err.Error())
+			fmt.Printf("pushBlocks blkbytes write %s\n", err.Error())
 			return
 		}
+
+		// then send a 4 byte length, then udata
+		// fmt.Printf("send ubb len %d\n", len(udb))
+		err = binary.Write(c, binary.BigEndian, uint32(len(udb)))
+		if err != nil {
+			fmt.Printf("pushBlocks binary.Write %s\n", err.Error())
+			return
+		}
+		n, err := c.Write(udb)
+		if err != nil {
+			fmt.Printf("pushBlocks ubb write %s\n", err.Error())
+			return
+		}
+		fmt.Printf("wrote %d bytes udb\n", n)
 	}
 	fmt.Printf("done pushing blocks to %s\n", c.RemoteAddr().String())
 	c.Close()

--- a/util/types.go
+++ b/util/types.go
@@ -195,7 +195,7 @@ func (ub *UBlock) Deserialize(r io.Reader) (err error) {
 		return
 	}
 
-	fmt.Printf("deser block OK %s\n", ub.Block.Header.BlockHash().String())
+	// fmt.Printf("deser block OK %s\n", ub.Block.Header.BlockHash().String())
 	var uDataLen, bytesRead uint32
 	var n int
 	// read udata length
@@ -203,7 +203,7 @@ func (ub *UBlock) Deserialize(r io.Reader) (err error) {
 	if err != nil {
 		return
 	}
-	fmt.Printf("server says %d byte uDataLen\n", uDataLen)
+	// fmt.Printf("server says %d byte uDataLen\n", uDataLen)
 
 	udataBytes := make([]byte, uDataLen)
 
@@ -214,7 +214,7 @@ func (ub *UBlock) Deserialize(r io.Reader) (err error) {
 		}
 		bytesRead += uint32(n)
 	}
-	fmt.Printf("udataBytes: %x\n", udataBytes)
+	// fmt.Printf("udataBytes: %x\n", udataBytes)
 	ub.ExtraData, err = UDataFromBytes(udataBytes)
 	return
 }

--- a/util/utils.go
+++ b/util/utils.go
@@ -351,10 +351,12 @@ func CheckMagicByte(bytesgiven []byte) bool {
 // Does NOT tell us if the file exists or not.
 // File might exist but may not be available to us
 func HasAccess(fileName string) bool {
-	if _, err := os.Stat(fileName); err != nil {
-		if os.IsNotExist(err) {
-			return false
-		}
+	stat, err := os.Stat(fileName)
+	if err != nil && os.IsNotExist(err) {
+		return false
+	}
+	if stat.Size() == 0 {
+		return false
 	}
 	return true
 }

--- a/util/utils.go
+++ b/util/utils.go
@@ -71,10 +71,11 @@ func UblockNetworkReader(
 		panic(err)
 	}
 
+	var ub UBlock
 	// TODO goroutines for only the Deserialize part might be nice.
 	// Need to sort the blocks though if you're doing that
 	for ; ; curHeight++ {
-		block, err := ReadBlock(con)
+		err = ub.Deserialize(con)
 		if err != nil {
 			if err == io.EOF {
 				close(blockChan)
@@ -82,43 +83,36 @@ func UblockNetworkReader(
 			}
 			panic(err)
 		}
-
-		var ub UBlock
-		bReader := bytes.NewReader(block)
-		err = ub.Deserialize(bReader)
-		if err != nil {
-			panic(err)
-		}
 		ub.Height = curHeight
 		blockChan <- ub
 	}
 }
 
-func ReadBlock(con net.Conn) ([]byte, error) {
-	// 4 bytes size of the payload is sent over
-	var sizeb [4]byte
+/*
+func ReadUBlockBytesFromCon(con net.Conn) ([]byte, error) {
+	// 4 bytes size of the whole payload (block + udata)
+	var size uint32
 
-	_, err := io.ReadFull(con, sizeb[:])
+	err := binary.Read(con, binary.BigEndian, &size)
 	if err != nil {
 		fmt.Println("size read err: ", err)
 		return nil, err
 	}
 
-	size := binary.BigEndian.Uint32(sizeb[:])
-	block := make([]byte, size)
+	blockBytes := make([]byte, size)
 
-	_, err = io.ReadFull(con, block)
+	_, err = io.ReadFull(con, blockBytes)
 	if err != nil {
 		fmt.Println("block read err: ", err)
 		return nil, err
 	}
-	return block, nil
+	return blockBytes, nil
 }
-
+*/
 // GetUDataFromFile reads the proof data from proof.dat and proofoffset.dat
 // and gives the proof & utxo data back.
 // Don't ask for block 0, there is no proof of that.
-func GetUDataFromFile(tipnum int32) (ud UData, err error) {
+func GetUDataBytesFromFile(tipnum int32) (b []byte, err error) {
 	if tipnum == 0 {
 		err = fmt.Errorf("Block 0 is not in blk files or utxo set")
 		return
@@ -162,19 +156,11 @@ func GetUDataFromFile(tipnum int32) (ud UData, err error) {
 		return
 	}
 
-	// +8 skips the 8 bytes of magicbytes and load size
-	// proofFile.Seek(int64(binary.BigEndian.Uint32(offset[:])+8), 0)
-	ubytes := make([]byte, size)
+	b = make([]byte, size)
 
-	_, err = proofFile.Read(ubytes)
+	_, err = proofFile.Read(b)
 	if err != nil {
 		err = fmt.Errorf("proofFile.Read(ubytes) %s", err.Error())
-		return
-	}
-
-	ud, err = UDataFromBytes(ubytes)
-	if err != nil {
-		err = fmt.Errorf("UDataFromBytes %s", err.Error())
 		return
 	}
 


### PR DESCRIPTION
The server would previously read blocks & udata from disk, deserialize them into data structures and then re-serialize them onto the network.  This PR changes the server so that it blindly reads bytes from files on disk and then sends them out over the network.

In the process I think I changed some of the serialization, like what length prefixes things have, so this may require a rebuild of the proof file, which means re-running utreexoserver from scratch.  Maybe not but if anything goes wrong that's the first thing to try.