### PR TITLE
Various Performance improvements

### DIFF
--- a/accumulator/hasher.go
+++ b/accumulator/hasher.go
@@ -1,26 +1,9 @@
 package accumulator
 
-import (
-	"sync"
-)
-
 // hashableNode is the data needed to perform a hash
 type hashableNode struct {
 	sib, dest *polNode
 	position  uint64 // doesn't really need to be there, but convenient for debugging
-}
-
-// this should work, right?  like the pointeryness?  Because swapnodes doesn't
-// change pointers.  Well it changes niece pointers, but the data itself changes
-// so the data is "there" in a static structure so I can use pointers to it
-// and it won't move around.  hopefully.
-
-func (n *hashableNode) run(wg *sync.WaitGroup) {
-	// fmt.Printf("hasher about to replace %x\n", n.dest.data[:4])
-	n.dest.data = n.sib.auntOp()
-	// fmt.Printf("hasher finished %x %x -> %x\n",
-	// n.sib.niece[0].data[:4], n.sib.niece[1].data[:4], n.dest.data[:4])
-	wg.Done()
 }
 
 type hashNpos struct {

--- a/bridgenode/server.go
+++ b/bridgenode/server.go
@@ -107,17 +107,25 @@ func serveBlocksWorker(c net.Conn, endHeight int32, blockDir string) {
 			fmt.Printf("pushBlocks blkbytes write %s\n", err.Error())
 			return
 		}
-		// send 4 byte udata length
-		// err = binary.Write(c, binary.BigEndian, uint32(len(udb)))
-		// if err != nil {
-		// 	fmt.Printf("pushBlocks binary.Write %s\n", err.Error())
-		// 	return
-		// }
-		// last, send the udata bytes
-		_, err = c.Write(udb)
+		// write the proof itself to the buffer
+		_, err = buf.Write(udb)
 		if err != nil {
 			fmt.Printf("pushBlocks ubb write %s\n", err.Error())
 			return
+		}
+
+		// Send to the client
+		payload := buf.Bytes()
+		// send the payload size to the client
+		err = binary.Write(c, binary.BigEndian, uint32(len(payload)))
+		if err != nil {
+			fmt.Printf("pushBlocks len write %s\n", err.Error())
+			return
+		}
+		// send the block + proofs to the client
+		_, err = c.Write(payload)
+		if err != nil {
+			fmt.Printf("pushBlocks payload write %s\n", err.Error())
 		}
 		// fmt.Printf("wrote %d bytes udb\n", n)
 	}


### PR DESCRIPTION
Changes were made to the accumulator and the utils

accumulator: More efficient pollard

Two things are changed:

1. Pollard no longer generates goroutines per parentHash in rem2. The
  bottleneck would come from the go scheduler deciding which goroutine to
  run. Resulting in the scheduler block being longer then the execution
  time. This also solves the datarace issue where duplicate hashes would
  be made

2. Gets rid of fmt from grabPos. This is helpful for reducing the gc
  latency as every fmt is a heap allocation.

utils: Restore buffered wire read and writes

This rolls back the changes so that the server and client doesn't do
many small reads, but rather 2 reads/sends per block