### PR TITLE
accumulator: More efficient pollard

### DIFF
--- a/accumulator/hasher.go
+++ b/accumulator/hasher.go
@@ -1,26 +1,9 @@
 package accumulator
 
-import (
-	"sync"
-)
-
 // hashableNode is the data needed to perform a hash
 type hashableNode struct {
 	sib, dest *polNode
 	position  uint64 // doesn't really need to be there, but convenient for debugging
-}
-
-// this should work, right?  like the pointeryness?  Because swapnodes doesn't
-// change pointers.  Well it changes niece pointers, but the data itself changes
-// so the data is "there" in a static structure so I can use pointers to it
-// and it won't move around.  hopefully.
-
-func (n *hashableNode) run(wg *sync.WaitGroup) {
-	// fmt.Printf("hasher about to replace %x\n", n.dest.data[:4])
-	n.dest.data = n.sib.auntOp()
-	// fmt.Printf("hasher finished %x %x -> %x\n",
-	// n.sib.niece[0].data[:4], n.sib.niece[1].data[:4], n.dest.data[:4])
-	wg.Done()
 }
 
 type hashNpos struct {


### PR DESCRIPTION
Two things are changed:

1. Pollard no longer generates goroutines per parentHash in rem2. The
bottleneck would come from the go scheduler deciding which goroutine to
run. Resulting in the scheduler block being longer then the execution
time. This also solves the datarace issue where duplicate hashes would
be made

2. Gets rid of fmt from grabPos. This is helpful for reducing the gc
latency as every fmt is a heap allocation.