### PR TITLE
cmd: Add tracing flags for the client and the server

### DIFF
--- a/bridgenode/genproofs.go
+++ b/bridgenode/genproofs.go
@@ -3,6 +3,8 @@ package bridgenode
 import (
 	"fmt"
 	"os"
+	"runtime/pprof"
+	"runtime/trace"
 	"sync"
 	"time"
 
@@ -296,6 +298,9 @@ func stopBuildProofs(
 
 	// Listen for SIGINT, SIGQUIT, SIGTERM
 	<-sig
+
+	trace.Stop()
+	pprof.StopCPUProfile()
 
 	// Sometimes there are bugs that make the program run forever.
 	// Utreexo binary should never take more than 10 seconds to exit

--- a/cmd/utreexoclient/csnclient.go
+++ b/cmd/utreexoclient/csnclient.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/signal"
 	"runtime/pprof"
+	"runtime/trace"
 	"syscall"
 
 	"github.com/btcsuite/btcd/chaincfg"
@@ -38,6 +39,8 @@ var cpuProfCmd = optionCmd.String("cpuprof", "",
 	`Enable pprof cpu profiling. Usage: 'cpuprof='path/to/file'`)
 var memProfCmd = optionCmd.String("memprof", "",
 	`Enable pprof heap profiling. Usage: 'memprof='path/to/file'`)
+var traceCmd = optionCmd.String("trace", "",
+	`Enable trace. Usage: 'trace='path/to/file'`)
 var watchAddr = optionCmd.String("watchaddr", "",
 	`Address to watch & report transactions. Only bech32 p2wpkh supported`)
 var remoteHost = optionCmd.String("host", "35.188.186.244",
@@ -88,9 +91,19 @@ func main() {
 		pprof.WriteHeapProfile(f)
 	}
 
+	if *traceCmd != "" {
+		f, err := os.Create(*traceCmd)
+		if err != nil {
+			fmt.Println(err)
+			fmt.Println(msg)
+			os.Exit(1)
+		}
+		trace.Start(f)
+	}
+
 	// listen for SIGINT, SIGTERM, or SIGQUIT from the os
 	sig := make(chan bool, 1)
-	handleIntSig(sig, *cpuProfCmd)
+	handleIntSig(sig, *cpuProfCmd, *traceCmd)
 
 	err := csn.RunIBD(&param, *remoteHost, *watchAddr, *checkSig, sig)
 	if err != nil {
@@ -98,13 +111,16 @@ func main() {
 	}
 }
 
-func handleIntSig(sig chan bool, cpuProfCmd string) {
+func handleIntSig(sig chan bool, cpuProfCmd, traceCmd string) {
 	s := make(chan os.Signal, 1)
 	signal.Notify(s, syscall.SIGINT, syscall.SIGQUIT, syscall.SIGTERM)
 	go func() {
 		<-s
 		if cpuProfCmd != "" {
 			pprof.StopCPUProfile()
+		}
+		if traceCmd != "" {
+			trace.Stop()
 		}
 		sig <- true
 	}()

--- a/csn/init.go
+++ b/csn/init.go
@@ -3,6 +3,8 @@ package csn
 import (
 	"fmt"
 	"os"
+	"runtime/pprof"
+	"runtime/trace"
 	"strings"
 	"time"
 
@@ -133,6 +135,8 @@ func initCSNState() (
 func stopRunIBD(sig chan bool, stopGoing chan bool, done chan bool) {
 	// Listen for SIGINT, SIGTERM, and SIGQUIT from the user
 	<-sig
+	pprof.StopCPUProfile()
+	trace.Stop()
 
 	// Sometimes there are bugs that make the program run forever.
 	// Utreexo binary should never take more than 10 seconds to exit


### PR DESCRIPTION
Adds a flag to enable tracing, a tool in the go standard toolchain. https://golang.org/cmd/trace/