### PR TITLE
accumulator/pollard: Speedups for pollard

### DIFF
--- a/accumulator/pollardproof.go
+++ b/accumulator/pollardproof.go
@@ -8,17 +8,15 @@ import (
 // targets in the block proof
 func (p *Pollard) IngestBatchProof(bp BatchProof) error {
 	var empty Hash
-
 	// TODO so many things to change
-	ok, proofMap := verifyBatchProof(
+	// Verify the proofs that was sent and returns a map of proofs to locations
+	ok, proofMap := p.verifyBatchProof(
 		bp, p.rootHashesReverse(), p.numLeaves, p.rows())
 	if !ok {
 		return fmt.Errorf("block proof mismatch")
 	}
-	//	fmt.Printf("targets: %v\n", bp.Targets)
 	// go through each target and populate pollard
 	for _, target := range bp.Targets {
-
 		tNum, branchLen, bits := detectOffset(target, p.numLeaves)
 		if branchLen == 0 {
 			// if there's no branch (1-tree) nothing to prove
@@ -37,7 +35,6 @@ func (p *Pollard) IngestBatchProof(bp BatchProof) error {
 			if node.niece[lr] == nil {
 				node.niece[lr] = new(polNode)
 				node.niece[lr].data = proofMap[pos]
-				// fmt.Printf("------wrote %x at %d\n", proofMap[pos], pos)
 				if node.niece[lr].data == empty {
 					return fmt.Errorf(
 						"h %d wrote empty hash at pos %d %04x.niece[%d]",
@@ -78,4 +75,136 @@ func (p *Pollard) IngestBatchProof(bp BatchProof) error {
 		}
 	}
 	return nil
+}
+
+// verifyBatchProof takes a block proof and reconstructs / verifies it.
+// takes a blockproof to verify, and the known correct roots to check against.
+// also takes the number of leaves and forest rows (those are redundant
+// if we don't do weird stuff with overly-high forests, which we might)
+// it returns a bool of whether the proof worked, and a map of the sparse
+// forest in the blockproof
+func (p *Pollard) verifyBatchProof(
+	bp BatchProof, roots []Hash,
+	numLeaves uint64, rows uint8) (bool, map[uint64]Hash) {
+
+	// if nothing to prove, it worked
+	if len(bp.Targets) == 0 {
+		return true, nil
+	}
+
+	// Construct a map with positions to hashes
+	proofmap, err := bp.Reconstruct(numLeaves, rows)
+	if err != nil {
+		fmt.Printf("VerifyBlockProof Reconstruct ERROR %s\n", err.Error())
+		return false, proofmap
+	}
+
+	rootPositions, rootRows := getRootsReverse(numLeaves, rows)
+
+	// partial forest is built, go through and hash everything to make sure
+	// you get the right roots
+
+	tagRow := bp.Targets
+	nextRow := []uint64{}
+	sortUint64s(tagRow) // probably don't need to sort
+
+	// TODO it's ugly that I keep treating the 0-row as a special case,
+	// and has led to a number of bugs.  It *is* special in a way, in that
+	// the bottom row is the only thing you actually prove and add/delete,
+	// but it'd be nice if it could all be treated uniformly.
+
+	if verbose {
+		fmt.Printf("tagrow len %d\n", len(tagRow))
+	}
+
+	var left, right uint64
+
+	// iterate through rows
+	for row := uint8(0); row <= rows; row++ {
+		// iterate through tagged positions in this row
+		for len(tagRow) > 0 {
+			//nextRow = make([]uint64, len(tagRow))
+			// Efficiency gains here. If there are two or more things to verify,
+			// check if the next thing to verify is the sibling of the current leaf
+			// we're on. Siblingness can be checked with bitwise XOR but since targets are
+			// sorted, we can do bitwise OR instead.
+			if len(tagRow) > 1 && tagRow[0]|1 == tagRow[1] {
+				left = tagRow[0]
+				right = tagRow[1]
+				tagRow = tagRow[2:]
+			} else { // if not only use one tagged position
+				right = tagRow[0] | 1
+				left = right ^ 1
+				tagRow = tagRow[1:]
+			}
+
+			if verbose {
+				fmt.Printf("left %d rootPoss %d\n", left, rootPositions[0])
+			}
+			// If the current node we're looking at this a root, check that
+			// it matches the one we stored
+			if left == rootPositions[0] {
+				if verbose {
+					fmt.Printf("one left in tagrow; should be root\n")
+				}
+				// Grab the received hash of this position from the map
+				// This is the one we received from our peer
+				computedRootHash, ok := proofmap[left]
+				if !ok {
+					fmt.Printf("ERR no proofmap for root at %d\n", left)
+					return false, nil
+				}
+				// Verify that this root hash matches the one we stored
+				if computedRootHash != roots[0] {
+					fmt.Printf("row %d root, pos %d expect %04x got %04x\n",
+						row, left, roots[0][:4], computedRootHash[:4])
+					return false, nil
+				}
+				// otherwise OK and pop of the root
+				roots = roots[1:]
+				rootPositions = rootPositions[1:]
+				rootRows = rootRows[1:]
+				break
+			}
+
+			// Grab the parent position of the leaf we've verified
+			parentPos := parent(left, rows)
+			if verbose {
+				fmt.Printf("%d %04x %d %04x -> %d\n",
+					left, proofmap[left], right, proofmap[right], parentPos)
+			}
+			var parhash Hash
+			n, _, _, err := p.readPos(parentPos)
+			if err != nil {
+				panic(err)
+			}
+
+			if n != nil && n.data != (Hash{}) {
+				parhash = n.data
+			} else {
+				// this will crash if either is 0000
+				// reconstruct the next row and add the parent to the map
+				parhash = parentHash(proofmap[left], proofmap[right])
+			}
+
+			//parhash := parentHash(proofmap[left], proofmap[right])
+			nextRow = append(nextRow, parentPos)
+			proofmap[parentPos] = parhash
+		}
+
+		// Make the nextRow the tagRow so we'll be iterating over it
+		// reset th nextRow
+		tagRow = nextRow
+		nextRow = []uint64{}
+
+		// if done with row and there's a root left on this row, remove it
+		if len(rootRows) > 0 && rootRows[0] == row {
+			// bit ugly to do these all separately eh
+			roots = roots[1:]
+			rootPositions = rootPositions[1:]
+			rootRows = rootRows[1:]
+		}
+	}
+
+	return true, proofmap
 }

--- a/accumulator/types.go
+++ b/accumulator/types.go
@@ -54,12 +54,9 @@ type simLeaf struct {
 // Parent gets you the merkle parent.  So far no committing to height.
 // if the left child is zero it should crash...
 func parentHash(l, r Hash) Hash {
-	var empty [32]byte
-	if l == empty {
-		panic("got a left empty here. ")
-	}
-	if r == empty {
-		panic("got a right empty here. ")
+	var empty Hash
+	if l == empty || r == empty {
+		panic("got an empty leaf here. ")
 	}
 	return sha256.Sum256(append(l[:], r[:]...))
 }

--- a/csn/ibd.go
+++ b/csn/ibd.go
@@ -127,7 +127,7 @@ func (c *Csn) ScanBlock(b wire.MsgBlock) {
 
 // Here we write proofs for all the txs.
 // All the inputs are saved as 32byte sha256 hashes.
-// All the outputs are saved as LeafTXO type.
+// All the outputs are saved as Leaf type.
 func (c *Csn) putBlockInPollard(
 	ub util.UBlock, totalTXOAdded, totalDels *int, plustime time.Duration) error {
 


### PR DESCRIPTION
Things done:

1. Different implementation of #3 where the already known hashes of parents were matched, saving sha256 hashes. Instead of going through all the nodes to the path of the leaf being verified, in this implementation just looks for the polNode at the parent position. New method on pollard ```readPos``` was needed as reading from ```grabPos``` created nil hashable nodes.

2. Various comments and small code fixes.

In my testing to block 600,000 on testnet3, the speedups were around 5%. However, when tested on blocks with lower height, the speedups were even less. So more hashing goes on as the tree gets bigger, leading to bigger savings. The matched hashes to the tip of the default server was 160,716,082 hashes and the unmatched hashes were 55,700,940 hashes. So this is around 75% of potential sha computation saved.