### PR TITLE
accumulator/utils: Much much faster treeRows

### DIFF
--- a/accumulator/utils.go
+++ b/accumulator/utils.go
@@ -2,6 +2,7 @@ package accumulator
 
 import (
 	"fmt"
+	"math"
 	"sort"
 )
 
@@ -181,12 +182,33 @@ func inForest(pos, numLeaves uint64, forestRows uint8) bool {
 	return pos < numLeaves
 }
 
-// given n leaves, how deep is the tree?
-// iterate shifting left until greater than n
-func treeRows(n uint64) (e uint8) {
-	for ; (1 << e) < n; e++ {
-	}
-	return
+// treeRows returns the number of rows given n leaves.
+func treeRows(n uint64) uint8 {
+	// treeRows works by:
+	// 1. Find the next power of 2 from the given n leaves.
+	// 2. Calculate the log2 of the result from step 1.
+	//
+	// For example, if the given number is 9, the next power of 2 is
+	// 16. This log2 of this number is how many rows there are in the
+	// given tree.
+	//
+	// This works because while Utreexo is a collection of perfect
+	// trees, the allocated number of leaves is always a power of 2.
+	// For Utreexo trees that don't have leaves that are power of 2,
+	// the extra space is just unallocated/filled with zeros.
+
+	// Find the next power of 2
+	n--
+	n |= n >> 1
+	n |= n >> 2
+	n |= n >> 4
+	n |= n >> 8
+	n |= n >> 16
+	n |= n >> 32
+	n++
+
+	// log of 2 is the tree depth/height
+	return uint8(math.Log2(float64(n)))
 }
 
 // numRoots is just a popCount function, returning the number of 1 bits

--- a/accumulator/utils_test.go
+++ b/accumulator/utils_test.go
@@ -1,0 +1,60 @@
+package accumulator
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestTreeRows(t *testing.T) {
+	// Test all the powers of 2
+	for i := uint8(1); i <= 63; i++ {
+		nLeaves := uint64(1 << i)
+		Orig := treeRowsOrig(nLeaves)
+		New := treeRows(nLeaves)
+		if Orig != New {
+			fmt.Printf("for n: %d;orig is %d. new is %d\n", nLeaves, Orig, New)
+			t.Fatal("treeRows and treeRowsOrig are not the same")
+		}
+
+	}
+	// Test billion leaves
+	for n := uint64(1); n <= 100000000; n++ {
+		Orig := treeRowsOrig(n)
+		New := treeRows(n)
+		if Orig != New {
+			fmt.Printf("for n: %d;orig is %d. new is %d\n", n, Orig, New)
+			t.Fatal("treeRows and treeRowsOrig are not the same")
+		}
+	}
+}
+
+// This is the orginal code for getting treeRows. The new function is tested
+// against it.
+func treeRowsOrig(n uint64) (e uint8) {
+	// Works by iteratations of shifting left until greater than n
+	for ; (1 << e) < n; e++ {
+	}
+	return
+}
+
+func BenchmarkTreeRows_HunThou(b *testing.B) { benchmarkTreeRows(100000, b) }
+func BenchmarkTreeRows_Mil(b *testing.B)     { benchmarkTreeRows(1000000, b) }
+func BenchmarkTreeRows_Bil(b *testing.B)     { benchmarkTreeRows(10000000, b) }
+func BenchmarkTreeRows_Tril(b *testing.B)    { benchmarkTreeRows(100000000, b) }
+
+func BenchmarkOrigTreeRows_HunThou(b *testing.B) { benchmarkTreeRowsOrig(100000, b) }
+func BenchmarkOrigTreeRows_Mil(b *testing.B)     { benchmarkTreeRowsOrig(1000000, b) }
+func BenchmarkOrigTreeRows_Bil(b *testing.B)     { benchmarkTreeRowsOrig(10000000, b) }
+func BenchmarkOrigTreeRows_Tril(b *testing.B)    { benchmarkTreeRowsOrig(100000000, b) }
+
+func benchmarkTreeRows(i uint64, b *testing.B) {
+	for n := uint64(1000000); n < i+1000000; n++ {
+		treeRows(n)
+	}
+}
+
+func benchmarkTreeRowsOrig(i uint64, b *testing.B) {
+	for n := uint64(1000000); n < i+1000000; n++ {
+		treeRowsOrig(n)
+	}
+}


### PR DESCRIPTION
```treeRows``` is called fairly often and from pprof results, treeRows is fairly high in the list of time taken. The current implementation is just bit shifting. I've implemented as:

1. Find the next power of 2
2. Take the log2 of that number

From this, I've gone ahead and implemented some bit tricks to really optimize it. 

![Screen Shot 2020-08-06 at 2 02 31 AM](https://user-images.githubusercontent.com/37185887/89443150-dce9f400-d78a-11ea-92be-1731af657161.png)

With the new implementation (thanks @dergoegge) treeRows now only takes ~2% of the time it originally took. My benchmarks are done on a laptop so it's not as good but the results from benchstat are:

```
[I] calvin@bitcoin ~/b/u/g/s/g/m/u/accumulator> benchstat old.txt new.txt
name                    old time/op  new time/op  delta
OrigTreeRows_HunThou-4  0.00ns ±19%  0.00ns ±13%   -98.51%  (p=0.008 n=5+5)
OrigTreeRows_Mil-4      0.02ns ± 1%  0.00ns ±13%   -97.71%  (p=0.008 n=5+5)
OrigTreeRows_Bil-4      0.22ns ± 1%  0.01ns ±35%   -97.47%  (p=0.008 n=5+5)
OrigTreeRows_Tril-4      2.50s ± 1%   0.00s ±12%  -100.00%  (p=0.008 n=5+5)
```


The savings increase as the number of times rem2 is called.

The actual bit trick algorithms implemented are modified from https://graphics.stanford.edu/~seander/bithacks.html#DetermineIfPowerOf2