### PR TITLE
accumulator: use bits.OnesCount64

### DIFF
--- a/accumulator/utils.go
+++ b/accumulator/utils.go
@@ -214,15 +214,9 @@ func treeRows(n uint64) uint8 {
 
 }
 
-// numRoots is just a popCount function, returning the number of 1 bits
-func numRoots(n uint64) (r uint8) {
-	for n > 0 {
-		if n&1 == 1 {
-			r++
-		}
-		n >>= 1
-	}
-	return
+// numRoots returns the number of 1 bits in n.
+func numRoots(n uint64) uint8 {
+	return uint8(bits.OnesCount64(n))
 }
 
 // rootPosition: given a number of leaves and a row, find the position of the


### PR DESCRIPTION
My first commit, I'll keep it short. 

The benchmark results,
```
go test -run=XXX -bench=BenchmarkNumRoots
goos: darwin
goarch: amd64
pkg: github.com/mit-dci/utreexo/accumulator
BenchmarkNumRootsOld-4   	16488475	        69.8 ns/op
BenchmarkNumRootsNew-4   	1000000000	         0.410 ns/op
PASS
ok  	github.com/mit-dci/utreexo/accumulator	1.685s
```

The code,
```go
func BenchmarkNumRootsOld(b *testing.B) {
	for i := 0; i < b.N; i++ {
		numRootsOld(1 << 63)
	}
}

func BenchmarkNumRootsNew(b *testing.B) {
	for i := 0; i < b.N; i++ {
		numRootsNew(1 << 63)
	}
}
```