### PR TITLE
refactor: Use slices instead of maps

### DIFF
--- a/accumulator/forest_test.go
+++ b/accumulator/forest_test.go
@@ -188,7 +188,7 @@ func addDelFullBatchProof(nAdds, nDels int) error {
 	}
 	bp.SortTargets()
 	// check block proof.  Note this doesn't delete anything, just proves inclusion
-	worked, _ := verifyBatchProof(bp, f.getRoots(), f.numLeaves, f.rows)
+	worked, _, _ := verifyBatchProof(bp, f.getRoots(), f.numLeaves, nil)
 	//	worked := f.VerifyBatchProof(bp)
 
 	if !worked {

--- a/accumulator/pollardproof.go
+++ b/accumulator/pollardproof.go
@@ -7,204 +7,97 @@ import (
 // IngestBatchProof populates the Pollard with all needed data to delete the
 // targets in the block proof
 func (p *Pollard) IngestBatchProof(bp BatchProof) error {
-	var empty Hash
-	// TODO so many things to change
-	// Verify the proofs that was sent and returns a map of proofs to locations
-	ok, proofMap := p.verifyBatchProof(
-		bp, p.rootHashesReverse(), p.numLeaves, p.rows())
+	// verify the batch proof.
+	rootHashes := p.rootHashesReverse()
+	ok, trees, roots := verifyBatchProof(bp, rootHashes, p.numLeaves,
+		// pass a closure that checks the pollard for cached nodes.
+		// returns true and the hash value of the node if it exists.
+		// returns false if the node does not exist or the hash value is empty.
+		func(pos uint64) (bool, Hash) {
+			n, _, _, err := p.readPos(pos)
+			if err != nil {
+				return false, empty
+			}
+			if n != nil && n.data != empty {
+				return true, n.data
+			}
+
+			return false, empty
+		})
 	if !ok {
 		return fmt.Errorf("block proof mismatch")
 	}
-	// go through each target and populate pollard
-	for _, target := range bp.Targets {
-		tNum, branchLen, bits := detectOffset(target, p.numLeaves)
-		if branchLen == 0 {
-			// if there's no branch (1-tree) nothing to prove
-			continue
+	// preallocating polNodes helps with garbage collection
+	polNodes := make([]polNode, len(trees)*3)
+	i := 0
+	nodesAllocated := 0
+	for _, root := range roots {
+		for root.Val != rootHashes[i] {
+			i++
 		}
-		node := p.roots[tNum]
-		h := branchLen - 1
-		pos := parentMany(target, branchLen, p.rows()) // this works but...
-		// we should have a way to get the root positions from just p.roots
-
-		lr := (bits >> h) & 1
-		pos = (child(pos, p.rows())) | lr
-		// descend until we hit the bottom, populating as we go
-		// also populate siblings...
-		for {
-			if node.niece[lr] == nil {
-				node.niece[lr] = new(polNode)
-				node.niece[lr].data = proofMap[pos]
-				if node.niece[lr].data == empty {
-					return fmt.Errorf(
-						"h %d wrote empty hash at pos %d %04x.niece[%d]",
-						h, pos, node.data[:4], lr)
-				}
-				// fmt.Printf("h %d wrote %04x to %d\n", h, node.niece[lr].data[:4], pos)
-				p.overWire++
-			}
-			if node.niece[lr^1] == nil {
-				node.niece[lr^1] = new(polNode)
-				node.niece[lr^1].data = proofMap[pos^1]
-				// doesn't count as overwire because computed, not read
-			}
-
-			if h == 0 {
-				break
-			}
-			h--
-			node = node.niece[lr]
-			lr = (bits >> h) & 1
-			pos = (child(pos, p.rows()) ^ 2) | lr
-		}
-
-		// TODO do you need this at all?  If the Verify part already happened, maybe not?
-		// at bottom, populate target if needed
-		// if we don't need this and take it out, will need to change the forget
-		// pop above
-
-		if node.niece[lr^1] == nil {
-			node.niece[lr^1] = new(polNode)
-			node.niece[lr^1].data = proofMap[pos^1]
-			fmt.Printf("------wrote %x at %d\n", proofMap[pos^1], pos^1)
-			if node.niece[lr^1].data == empty {
-				return fmt.Errorf("Wrote an empty hash h %d under %04x %d.niece[%d]",
-					h, node.data[:4], pos, lr^1)
-			}
-			// p.overWire++ // doesn't count...? got it for free?
-		}
+		// populate the pollard
+		nodesAllocated += p.populate(p.roots[len(p.roots)-i-1], root.Pos,
+			trees, polNodes[nodesAllocated:])
 	}
+
 	return nil
 }
 
-// verifyBatchProof takes a block proof and reconstructs / verifies it.
-// takes a blockproof to verify, and the known correct roots to check against.
-// also takes the number of leaves and forest rows (those are redundant
-// if we don't do weird stuff with overly-high forests, which we might)
-// it returns a bool of whether the proof worked, and a map of the sparse
-// forest in the blockproof
-func (p *Pollard) verifyBatchProof(
-	bp BatchProof, roots []Hash,
-	numLeaves uint64, rows uint8) (bool, map[uint64]Hash) {
-
-	// if nothing to prove, it worked
-	if len(bp.Targets) == 0 {
-		return true, nil
+// populate takes a root and populates it with the nodes of the paritial proof tree that was computed
+// in `verifyBatchProof`.
+func (p *Pollard) populate(root *polNode, pos uint64, trees [][3]node, polNodes []polNode) int {
+	// a stack to traverse the pollard
+	type stackElem struct {
+		trees [][3]node
+		node  *polNode
+		pos   uint64
 	}
+	stack := make([]stackElem, 0, len(trees))
+	stack = append(stack, stackElem{trees, root, pos})
+	rows := p.rows()
+	nodesAllocated := 0
+	for len(stack) > 0 {
+		elem := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
 
-	// Construct a map with positions to hashes
-	proofmap, err := bp.Reconstruct(numLeaves, rows)
-	if err != nil {
-		fmt.Printf("VerifyBlockProof Reconstruct ERROR %s\n", err.Error())
-		return false, proofmap
-	}
-
-	rootPositions, rootRows := getRootsReverse(numLeaves, rows)
-
-	// partial forest is built, go through and hash everything to make sure
-	// you get the right roots
-
-	tagRow := bp.Targets
-	nextRow := []uint64{}
-	sortUint64s(tagRow) // probably don't need to sort
-
-	// TODO it's ugly that I keep treating the 0-row as a special case,
-	// and has led to a number of bugs.  It *is* special in a way, in that
-	// the bottom row is the only thing you actually prove and add/delete,
-	// but it'd be nice if it could all be treated uniformly.
-
-	if verbose {
-		fmt.Printf("tagrow len %d\n", len(tagRow))
-	}
-
-	var left, right uint64
-
-	// iterate through rows
-	for row := uint8(0); row <= rows; row++ {
-		// iterate through tagged positions in this row
-		for len(tagRow) > 0 {
-			//nextRow = make([]uint64, len(tagRow))
-			// Efficiency gains here. If there are two or more things to verify,
-			// check if the next thing to verify is the sibling of the current leaf
-			// we're on. Siblingness can be checked with bitwise XOR but since targets are
-			// sorted, we can do bitwise OR instead.
-			if len(tagRow) > 1 && tagRow[0]|1 == tagRow[1] {
-				left = tagRow[0]
-				right = tagRow[1]
-				tagRow = tagRow[2:]
-			} else { // if not only use one tagged position
-				right = tagRow[0] | 1
-				left = right ^ 1
-				tagRow = tagRow[1:]
-			}
-
-			if verbose {
-				fmt.Printf("left %d rootPoss %d\n", left, rootPositions[0])
-			}
-			// If the current node we're looking at this a root, check that
-			// it matches the one we stored
-			if left == rootPositions[0] {
-				if verbose {
-					fmt.Printf("one left in tagrow; should be root\n")
-				}
-				// Grab the received hash of this position from the map
-				// This is the one we received from our peer
-				computedRootHash, ok := proofmap[left]
-				if !ok {
-					fmt.Printf("ERR no proofmap for root at %d\n", left)
-					return false, nil
-				}
-				// Verify that this root hash matches the one we stored
-				if computedRootHash != roots[0] {
-					fmt.Printf("row %d root, pos %d expect %04x got %04x\n",
-						row, left, roots[0][:4], computedRootHash[:4])
-					return false, nil
-				}
-				// otherwise OK and pop of the root
-				roots = roots[1:]
-				rootPositions = rootPositions[1:]
-				rootRows = rootRows[1:]
-				break
-			}
-
-			// Grab the parent position of the leaf we've verified
-			parentPos := parent(left, rows)
-			if verbose {
-				fmt.Printf("%d %04x %d %04x -> %d\n",
-					left, proofmap[left], right, proofmap[right], parentPos)
-			}
-			var parhash Hash
-			n, _, _, err := p.readPos(parentPos)
-			if err != nil {
-				panic(err)
-			}
-
-			if n != nil && n.data != (Hash{}) {
-				parhash = n.data
-			} else {
-				// this will crash if either is 0000
-				// reconstruct the next row and add the parent to the map
-				parhash = parentHash(proofmap[left], proofmap[right])
-			}
-
-			//parhash := parentHash(proofmap[left], proofmap[right])
-			nextRow = append(nextRow, parentPos)
-			proofmap[parentPos] = parhash
+		if elem.pos < p.numLeaves {
+			// this is a leaf, we are done populating this branch.
+			continue
 		}
 
-		// Make the nextRow the tagRow so we'll be iterating over it
-		// reset th nextRow
-		tagRow = nextRow
-		nextRow = []uint64{}
-
-		// if done with row and there's a root left on this row, remove it
-		if len(rootRows) > 0 && rootRows[0] == row {
-			// bit ugly to do these all separately eh
-			roots = roots[1:]
-			rootPositions = rootPositions[1:]
-			rootRows = rootRows[1:]
+		leftChild := child(elem.pos, rows)
+		rightChild := child(elem.pos, rows) | 1
+		var left, right *polNode
+		i := len(elem.trees) - 1
+	find_nodes:
+		for ; i >= 0; i-- {
+			switch elem.trees[i][0].Pos {
+			case elem.pos:
+				fallthrough
+			case rightChild:
+				if elem.node.niece[0] == nil {
+					elem.node.niece[0] = &polNodes[nodesAllocated]
+					nodesAllocated++
+				}
+				right = elem.node.niece[0]
+				right.data = elem.trees[i][1].Val
+				fallthrough
+			case leftChild:
+				if elem.node.niece[1] == nil {
+					elem.node.niece[1] = &polNodes[nodesAllocated]
+					nodesAllocated++
+				}
+				left = elem.node.niece[1]
+				left.data = elem.trees[i][2].Val
+				break find_nodes
+			}
 		}
-	}
+		if i < 0 {
+			continue
+		}
 
-	return true, proofmap
+		stack = append(stack,
+			stackElem{trees[:i], left, leftChild}, stackElem{trees[:i], right, rightChild})
+	}
+	return nodesAllocated
 }

--- a/accumulator/utils.go
+++ b/accumulator/utils.go
@@ -9,6 +9,87 @@ import (
 // verbose is a global const to get lots of printfs for debugging
 var verbose = false
 
+// ProofPositions returns the positions that are needed to prove that the targets exist.
+func ProofPositions(targets []uint64, numLeaves uint64, forestRows uint8) ([]uint64, []uint64) {
+	// the proofPositions needed without caching.
+	proofPositions := make([]uint64, 0, len(targets)*int(forestRows))
+	// the positions that are computed/not included in the proof. (also includes the targets)
+	computedPositions := make([]uint64, 0, len(targets)*int(forestRows))
+	for row := uint8(0); row < forestRows; row++ {
+		computedPositions = append(computedPositions, targets...)
+		if numLeaves&(1<<row) > 0 && len(targets) > 0 &&
+			targets[len(targets)-1] == rootPosition(numLeaves, row, forestRows) {
+			// remove roots from targets
+			targets = targets[:len(targets)-1]
+		}
+
+		var nextTargets []uint64
+		for len(targets) > 0 {
+			switch {
+			// look at the first 4 targets
+			case len(targets) > 3:
+				if (targets[0]|1)^2 == targets[3]|1 {
+					// the first and fourth target are cousins
+					// => target 2 and 3 are also targets, both parents are targets of next row
+					nextTargets = append(nextTargets,
+						parent(targets[0], forestRows), parent(targets[3], forestRows))
+					targets = targets[4:]
+					break
+				}
+				// handle first three targets
+				fallthrough
+
+			// look at the first 3 targets
+			case len(targets) > 2:
+				if (targets[0]|1)^2 == targets[2]|1 {
+					// the first and third target are cousins
+					// => the second target is either the sibling of the first
+					// OR the sibiling of the third
+					// => only the sibling that is not a target is appended to the proof positions
+					if targets[1]|1 == targets[0]|1 {
+						proofPositions = append(proofPositions, targets[2]^1)
+					} else {
+						proofPositions = append(proofPositions, targets[0]^1)
+					}
+					// both parents are targets of next row
+					nextTargets = append(nextTargets,
+						parent(targets[0], forestRows), parent(targets[2], forestRows))
+					targets = targets[3:]
+					break
+				}
+				// handle first two targets
+				fallthrough
+
+			// look at the first 2 targets
+			case len(targets) > 1:
+				if targets[0]|1 == targets[1] {
+					nextTargets = append(nextTargets, parent(targets[0], forestRows))
+					targets = targets[2:]
+					break
+				}
+				if (targets[0]|1)^2 == targets[1]|1 {
+					proofPositions = append(proofPositions, targets[0]^1, targets[1]^1)
+					nextTargets = append(nextTargets,
+						parent(targets[0], forestRows), parent(targets[1], forestRows))
+					targets = targets[2:]
+					break
+				}
+				// not related, handle first target
+				fallthrough
+
+			// look at the first target
+			default:
+				proofPositions = append(proofPositions, targets[0]^1)
+				nextTargets = append(nextTargets, parent(targets[0], forestRows))
+				targets = targets[1:]
+			}
+		}
+		targets = nextTargets
+	}
+
+	return proofPositions, computedPositions
+}
+
 // takes a slice of dels, removes the twins (in place) and returns a slice
 // of parents of twins
 //


### PR DESCRIPTION
was part of my experiments in #180.
Refactor `ProveBatch`, `verifyBatchProof` and `IngestBatchProof` to use slices.
Preallocation of slices also helps with GC pressure. 
also includes the `ProofPositions` function which is also part of #185, kinda stupid but otherwise this doesn't build.