### PR TITLE
pollard: Make addOne remember leaf siblings correctly

### DIFF
--- a/accumulator/pollard.go
+++ b/accumulator/pollard.go
@@ -114,11 +114,17 @@ func (p *Pollard) addOne(add Hash, remember bool) error {
 	// loop until we find a zero; destroy roots until you make one
 	for ; (p.numLeaves>>h)&1 == 1; h++ {
 		// grab, pop, swap, hash, new
-		leftRoot := p.roots[len(p.roots)-1]                         // grab
-		p.roots = p.roots[:len(p.roots)-1]                          // pop
-		leftRoot.niece, n.niece = n.niece, leftRoot.niece           // swap
-		nHash := parentHash(leftRoot.data, n.data)                  // hash
-		n = &polNode{data: nHash, niece: [2]*polNode{&leftRoot, n}} // new
+		leftRoot := p.roots[len(p.roots)-1] // grab
+		p.roots = p.roots[:len(p.roots)-1]  // pop
+
+		if h == 0 && remember {
+			// make sure that siblings are always remembered in pairs.
+			leftRoot.niece[0] = leftRoot
+		}
+
+		leftRoot.niece, n.niece = n.niece, leftRoot.niece          // swap
+		nHash := parentHash(leftRoot.data, n.data)                 // hash
+		n = &polNode{data: nHash, niece: [2]*polNode{leftRoot, n}} // new
 		p.hashesEver++
 
 		n.prune()
@@ -129,7 +135,7 @@ func (p *Pollard) addOne(add Hash, remember bool) error {
 	// we got to.  We've already deleted all the lower roots, so append the new
 	// one we just made onto the end.
 
-	p.roots = append(p.roots, *n)
+	p.roots = append(p.roots, n)
 	p.numLeaves++
 	return nil
 }
@@ -240,7 +246,7 @@ func (p *Pollard) rem2(dels []uint64) error {
 	// fmt.Printf("preroot %s", p.toString())
 	// set new roots
 	nextRootPositions, _ := getRootsReverse(nextNumLeaves, ph)
-	nextRoots := make([]polNode, len(nextRootPositions))
+	nextRoots := make([]*polNode, len(nextRootPositions))
 	for i, _ := range nextRoots {
 		nt, ntsib, _, err := p.grabPos(nextRootPositions[i])
 		if err != nil {
@@ -256,7 +262,7 @@ func (p *Pollard) rem2(dels []uint64) error {
 		} else {
 			nt.niece = ntsib.niece
 		}
-		nextRoots[i] = *nt
+		nextRoots[i] = nt
 	}
 	p.numLeaves = nextNumLeaves
 	reversePolNodeSlice(nextRoots)
@@ -340,7 +346,7 @@ func (p *Pollard) readPos(pos uint64) (
 		err = ErrorStrings[ErrorNotEnoughTrees]
 		return
 	}
-	n, nsib = &p.roots[tree], &p.roots[tree]
+	n, nsib = p.roots[tree], p.roots[tree]
 
 	for h := branchLen - 1; h != 255; h-- { // go through branch
 		lr := uint8(bits>>h) & 1
@@ -349,11 +355,6 @@ func (p *Pollard) readPos(pos uint64) (
 		if h == 0 { // if at bottom, done
 			n, nsib = n.niece[lrSib], n.niece[lr]
 			return
-		}
-
-		// if a sib is nil, we don't have the node stored. return nil
-		if n.niece[lrSib] == nil {
-			return nil, nil, nil, err
 		}
 
 		n, nsib = n.niece[lr], n.niece[lrSib]
@@ -376,7 +377,7 @@ func (p *Pollard) grabPos(
 		err = ErrorStrings[ErrorNotEnoughTrees]
 		return
 	}
-	n, nsib = &p.roots[tree], &p.roots[tree]
+	n, nsib = p.roots[tree], p.roots[tree]
 
 	hn = &hashableNode{dest: n, sib: nsib}
 	for h := branchLen - 1; h != 255; h-- { // go through branch
@@ -425,7 +426,7 @@ func (p *Pollard) descendToPos(pos uint64) ([]*polNode, []*polNode, error) {
 	// first find which tree we're in
 	tNum, branchLen, bits := detectOffset(pos, p.numLeaves)
 	//	fmt.Printf("DO pos %d root %d bits %d branlen %d\n", pos, tNum, bits, branchLen)
-	n := &p.roots[tNum]
+	n := p.roots[tNum]
 	if branchLen > 64 {
 		return nil, nil, fmt.Errorf("dtp root %d is nil", tNum)
 	}

--- a/accumulator/pollardproof.go
+++ b/accumulator/pollardproof.go
@@ -22,7 +22,7 @@ func (p *Pollard) IngestBatchProof(bp BatchProof) error {
 			// if there's no branch (1-tree) nothing to prove
 			continue
 		}
-		node := &p.roots[tNum]
+		node := p.roots[tNum]
 		h := branchLen - 1
 		pos := parentMany(target, branchLen, p.rows()) // this works but...
 		// we should have a way to get the root positions from just p.roots

--- a/accumulator/pollardutil.go
+++ b/accumulator/pollardutil.go
@@ -17,7 +17,7 @@ import (
 type Pollard struct {
 	numLeaves uint64 // number of leaves in the pollard forest
 
-	roots []polNode // slice of the tree roots, which are polNodes.
+	roots []*polNode // slice of the tree roots, which are polNodes.
 	// roots are in big to small order
 	// BUT THEY'RE WEIRD!  The left / right children are actual children,
 	// not nieces as they are in every lower level.
@@ -149,9 +149,10 @@ func (p *Pollard) RestorePollard(r io.Reader) error {
 		return err
 	}
 
-	p.roots = make([]polNode, numRoots(p.numLeaves))
+	p.roots = make([]*polNode, numRoots(p.numLeaves))
 	fmt.Printf("%d leaves %d roots ", p.numLeaves, len(p.roots))
 	for i, _ := range p.roots {
+		p.roots[i] = new(polNode)
 		bytesRead, err := r.Read(p.roots[i].data[:])
 		// ignore EOF error at the end of successful reading
 		if err != nil && !(bytesRead == 32 && err == io.EOF) {

--- a/accumulator/utils.go
+++ b/accumulator/utils.go
@@ -361,7 +361,7 @@ func reverseUint64Slice(a []uint64) {
 	}
 }
 
-func reversePolNodeSlice(a []polNode) {
+func reversePolNodeSlice(a []*polNode) {
 	for i, j := 0, len(a)-1; i < j; i, j = i+1, j-1 {
 		a[i], a[j] = a[j], a[i]
 	}


### PR DESCRIPTION
There was a bug in `addOne` that made the pollard not remember a leaf, see #180 for details.
This PR also refactors the roots to be pointers to `polNode` and makes readPos not stop at nil siblings.