### PR TITLE
accumulator: Use sha512/256 instead of sha256

### DIFF
--- a/accumulator/types.go
+++ b/accumulator/types.go
@@ -2,6 +2,7 @@ package accumulator
 
 import (
 	"crypto/sha256"
+	"crypto/sha512"
 	"fmt"
 	"math/rand"
 )
@@ -58,7 +59,7 @@ func parentHash(l, r Hash) Hash {
 	if l == empty || r == empty {
 		panic("got an empty leaf here. ")
 	}
-	return sha256.Sum256(append(l[:], r[:]...))
+	return sha512.Sum512_256(append(l[:], r[:]...))
 }
 
 // SimChain is for testing; it spits out "blocks" of adds and deletes

--- a/util/types.go
+++ b/util/types.go
@@ -3,6 +3,7 @@ package util
 import (
 	"bytes"
 	"crypto/sha256"
+	"crypto/sha512"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -152,7 +153,7 @@ func LeafDataFromCompactBytes(b []byte) (LeafData, error) {
 
 // LeafHash turns a LeafData into a LeafHash
 func (l *LeafData) LeafHash() [32]byte {
-	return sha256.Sum256(l.ToBytes())
+	return sha512.Sum512_256(l.ToBytes())
 }
 
 func LeafDataFromTxo(txo wire.TxOut) (LeafData, error) {


### PR DESCRIPTION
I tested this up until block #300000 and sha512 seems to be a bit faster. (1.3x faster in my test)
[pprof_files.zip](https://github.com/mit-dci/utreexo/files/5126671/pprof_files.zip)
