### PR TITLE
Split proof building and serving functions

### DIFF
--- a/bridgenode/chainio.go
+++ b/bridgenode/chainio.go
@@ -78,7 +78,6 @@ func restoreForest(
 
 // restoreHeight restores height from util.ForestLastSyncedBlockHeightFilePath
 func restoreHeight() (height int32, err error) {
-
 	// if there is a heightfile, get the height from that
 	// heightFile saves the last block that was written to ttldb
 	if util.HasAccess(util.ForestLastSyncedBlockHeightFilePath) {

--- a/bridgenode/chainio.go
+++ b/bridgenode/chainio.go
@@ -2,6 +2,7 @@ package bridgenode
 
 import (
 	"encoding/binary"
+	"fmt"
 	"os"
 
 	"github.com/btcsuite/btcd/chaincfg"
@@ -91,6 +92,9 @@ func restoreHeight() (height int32, err error) {
 		if err != nil {
 			return 0, err
 		}
+	} else {
+		return 0, fmt.Errorf("can't read height at %s\n",
+			util.ForestLastSyncedBlockHeightFilePath)
 	}
 	return
 }

--- a/bridgenode/genproofs.go
+++ b/bridgenode/genproofs.go
@@ -151,16 +151,6 @@ func BuildProofs(
 
 	fmt.Println("Done writing")
 
-	if stop {
-		// genproofs was paused.
-		// Tell stopBuildProofs that it's ok to exit
-		haltAccept <- true
-		return nil
-	}
-
-	// should be a goroutine..?  isn't right now
-	blockServer(knownTipHeight, dataDir, haltRequest, haltAccept, lvdb)
-
 	// Tell stopBuildProofs that it's ok to exit
 	haltAccept <- true
 	return nil

--- a/bridgenode/genproofs.go
+++ b/bridgenode/genproofs.go
@@ -297,7 +297,13 @@ func stopBuildProofs(
 	sig, offsetfinished, haltRequest, haltAccept chan bool) {
 
 	// Listen for SIGINT, SIGQUIT, SIGTERM
-	<-sig
+	// Also listen for an unrequested haltAccept which means upstream is finshed
+	// and to end this goroutine
+	select {
+	case <-haltAccept:
+		return
+	case <-sig:
+	}
 
 	trace.Stop()
 	pprof.StopCPUProfile()

--- a/bridgenode/server.go
+++ b/bridgenode/server.go
@@ -80,7 +80,6 @@ func stopServer(sig, haltRequest, haltAccept chan bool) {
 // ublocks blocks over that connection
 func blockServer(endHeight int32, dataDir string, haltRequest,
 	haltAccept chan bool, lvdb *leveldb.DB) {
-	endHeight-- // TODO make sure the -1 makes sense here
 	fmt.Printf("serving up to & including block height %d\n", endHeight)
 	listenAdr, err := net.ResolveTCPAddr("tcp", "0.0.0.0:8338")
 	if err != nil {

--- a/bridgenode/server.go
+++ b/bridgenode/server.go
@@ -14,7 +14,7 @@ import (
 	"github.com/syndtr/goleveldb/leveldb/opt"
 )
 
-func ServeBlock(param chaincfg.Params, dataDir string, sig chan bool) error {
+func ArchiveServer(param chaincfg.Params, dataDir string, sig chan bool) error {
 
 	// Channel to alert the tell the main loop it's ok to exit
 	haltRequest := make(chan bool, 1)
@@ -80,6 +80,8 @@ func stopServer(sig, haltRequest, haltAccept chan bool) {
 // ublocks blocks over that connection
 func blockServer(endHeight int32, dataDir string, haltRequest,
 	haltAccept chan bool, lvdb *leveldb.DB) {
+	endHeight--
+	fmt.Printf("serving up to block height %d\n", endHeight)
 	listenAdr, err := net.ResolveTCPAddr("tcp", "0.0.0.0:8338")
 	if err != nil {
 		fmt.Printf(err.Error())

--- a/bridgenode/server.go
+++ b/bridgenode/server.go
@@ -10,7 +10,7 @@ import (
 	"runtime/trace"
 	"time"
 
-	"github.com/adiabat/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/mit-dci/utreexo/util"
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/opt"

--- a/bridgenode/server.go
+++ b/bridgenode/server.go
@@ -6,9 +6,14 @@ import (
 	"math"
 	"net"
 
+	"github.com/adiabat/btcd/chaincfg"
 	"github.com/mit-dci/utreexo/util"
 	"github.com/syndtr/goleveldb/leveldb"
 )
+
+func ServeBlock(param chaincfg.Params, dataDir string, sig chan bool) error {
+	return nil
+}
 
 // blockServer listens on a TCP port for incoming connections, then gives
 // ublocks blocks over that connection

--- a/bridgenode/server.go
+++ b/bridgenode/server.go
@@ -6,8 +6,6 @@ import (
 	"math"
 	"net"
 	"os"
-	"runtime/pprof"
-	"runtime/trace"
 	"time"
 
 	"github.com/btcsuite/btcd/chaincfg"
@@ -56,14 +54,11 @@ func stopServer(sig, haltRequest, haltAccept chan bool) {
 
 	// Listen for SIGINT, SIGQUIT, SIGTERM
 	<-sig
-
-	trace.Stop()
-	pprof.StopCPUProfile()
-
+	haltRequest <- true
 	// Sometimes there are bugs that make the program run forever.
 	// Utreexo binary should never take more than 10 seconds to exit
 	go func() {
-		time.Sleep(60 * time.Second)
+		time.Sleep(2 * time.Second)
 		fmt.Println("Exit timed out. Force quitting.")
 		os.Exit(1)
 	}()
@@ -94,7 +89,6 @@ func blockServer(endHeight int32, dataDir string, haltRequest,
 
 	cons := make(chan net.Conn)
 	go acceptConnections(listener, cons)
-
 	for {
 		select {
 		case <-haltRequest:

--- a/bridgenode/server.go
+++ b/bridgenode/server.go
@@ -80,8 +80,8 @@ func stopServer(sig, haltRequest, haltAccept chan bool) {
 // ublocks blocks over that connection
 func blockServer(endHeight int32, dataDir string, haltRequest,
 	haltAccept chan bool, lvdb *leveldb.DB) {
-	endHeight--
-	fmt.Printf("serving up to block height %d\n", endHeight)
+	endHeight-- // TODO make sure the -1 makes sense here
+	fmt.Printf("serving up to & including block height %d\n", endHeight)
 	listenAdr, err := net.ResolveTCPAddr("tcp", "0.0.0.0:8338")
 	if err != nil {
 		fmt.Printf(err.Error())

--- a/cmd/utreexoserver/bridgeserver.go
+++ b/cmd/utreexoserver/bridgeserver.go
@@ -120,19 +120,18 @@ func main() {
 	// only do buildProofs or serve; need to restart to serve after
 	// building proofs
 
-	if *serve {
-		err := bridge.ServeBlock(param, dataDir, sig)
-		if err != nil {
-			fmt.Printf("ServeBlocks error: %s\n", err.Error())
-			panic("server halting")
-		}
-	} else {
+	if !*serve {
 		fmt.Printf("datadir is %s\n", dataDir)
 		err := bridge.BuildProofs(param, dataDir, *forestInRam, *forestCache, sig)
 		if err != nil {
 			fmt.Printf("Buildproofs error: %s\n", err.Error())
 			panic("proof build halting")
 		}
+	}
+	err := bridge.ArchiveServer(param, dataDir, sig)
+	if err != nil {
+		fmt.Printf("ServeBlocks error: %s\n", err.Error())
+		panic("server halting")
 	}
 }
 

--- a/cmd/utreexoserver/bridgeserver.go
+++ b/cmd/utreexoserver/bridgeserver.go
@@ -117,7 +117,16 @@ func main() {
 	sig := make(chan bool, 1)
 	handleIntSig(sig, *cpuProfCmd, *traceCmd)
 
-	if !*serve {
+	// only do buildProofs or serve; need to restart to serve after
+	// building proofs
+
+	if *serve {
+		err := bridge.ServeBlock(param, dataDir, sig)
+		if err != nil {
+			fmt.Printf("ServeBlocks error: %s\n", err.Error())
+			panic("server halting")
+		}
+	} else {
 		fmt.Printf("datadir is %s\n", dataDir)
 		err := bridge.BuildProofs(param, dataDir, *forestInRam, *forestCache, sig)
 		if err != nil {
@@ -125,12 +134,6 @@ func main() {
 			panic("proof build halting")
 		}
 	}
-	err := bridge.ServeBlock(param, dataDir, sig)
-	if err != nil {
-		fmt.Printf("ServeBlocks error: %s\n", err.Error())
-		panic("server halting")
-	}
-
 }
 
 func handleIntSig(sig chan bool, cpuProfCmd, traceCmd string) {

--- a/cmd/utreexoserver/bridgeserver.go
+++ b/cmd/utreexoserver/bridgeserver.go
@@ -30,6 +30,7 @@ OPTIONS:
 
   -cpuprof                     configure whether to use use cpu profiling
   -memprof                     configure whether to use use heap profiling
+  -serve						 immediately serve whatever data is built
 
 `
 
@@ -44,6 +45,8 @@ var forestInRam = optionCmd.Bool("inram", false,
 	`keep forest in ram instead of disk.  Faster but needs lots of ram`)
 var forestCache = optionCmd.Bool("cache", false,
 	`use ram-cached forest.  Speed between on disk and fully in-ram`)
+var serve = optionCmd.Bool("serve", false,
+	`immediately start server without building or checking proof data`)
 var traceCmd = optionCmd.String("trace", "",
 	`Enable trace. Usage: 'trace='path/to/file'`)
 var cpuProfCmd = optionCmd.String("cpuprof", "",
@@ -114,10 +117,17 @@ func main() {
 	sig := make(chan bool, 1)
 	handleIntSig(sig, *cpuProfCmd, *traceCmd)
 
-	fmt.Printf("datadir is %s\n", dataDir)
-	err := bridge.BuildProofs(param, dataDir, *forestInRam, *forestCache, sig)
+	if !*serve {
+		fmt.Printf("datadir is %s\n", dataDir)
+		err := bridge.BuildProofs(param, dataDir, *forestInRam, *forestCache, sig)
+		if err != nil {
+			fmt.Printf("Buildproofs error: %s\n", err.Error())
+			panic("proof build halting")
+		}
+	}
+	err := bridge.ServeBlocks(param, dataDir, sig)
 	if err != nil {
-		fmt.Printf("Buildproofs error: %s\n", err.Error())
+		fmt.Printf("ServeBlocks error: %s\n", err.Error())
 		panic("server halting")
 	}
 

--- a/cmd/utreexoserver/bridgeserver.go
+++ b/cmd/utreexoserver/bridgeserver.go
@@ -125,7 +125,7 @@ func main() {
 			panic("proof build halting")
 		}
 	}
-	err := bridge.ServeBlocks(param, dataDir, sig)
+	err := bridge.ServeBlock(param, dataDir, sig)
 	if err != nil {
 		fmt.Printf("ServeBlocks error: %s\n", err.Error())
 		panic("server halting")

--- a/cmd/utreexoserver/bridgeserver.go
+++ b/cmd/utreexoserver/bridgeserver.go
@@ -130,7 +130,7 @@ func main() {
 	}
 	err := bridge.ArchiveServer(param, dataDir, sig)
 	if err != nil {
-		fmt.Printf("ServeBlocks error: %s\n", err.Error())
+		fmt.Printf("ArchiveServer error: %s\n", err.Error())
 		panic("server halting")
 	}
 }

--- a/test/install_bitcoind.sh
+++ b/test/install_bitcoind.sh
@@ -13,7 +13,7 @@ then
 else
         mkdir -p ~/bitcoin && \
         pushd ~/bitcoin && \
-        wget https://adiabat.github.io/bitcoin-$BITCOIND_VERSION-x86_64-linux-gnu.tar.gz && \
+        wget -q https://adiabat.github.io/bitcoin-$BITCOIND_VERSION-x86_64-linux-gnu.tar.gz && \
         tar xvfz bitcoin-$BITCOIND_VERSION-x86_64-linux-gnu.tar.gz && \
         sudo cp ./bitcoin-$BITCOIND_VERSION/bin/bitcoind /usr/local/bin/bitcoind && \
         sudo cp ./bitcoin-$BITCOIND_VERSION/bin/bitcoin-cli /usr/local/bin/bitcoin-cli && \

--- a/test/install_bitcoind.sh
+++ b/test/install_bitcoind.sh
@@ -5,7 +5,7 @@
 
 set -ev
 
-export BITCOIND_VERSION=0.20.0
+export BITCOIND_VERSION=0.20.1
 
 if sudo cp ~/bitcoin/bitcoin-$BITCOIND_VERSION/bin/bitcoind /usr/local/bin/bitcoind
 then
@@ -13,7 +13,7 @@ then
 else
         mkdir -p ~/bitcoin && \
         pushd ~/bitcoin && \
-        wget https://bitcoin.org/bin/bitcoin-core-$BITCOIND_VERSION/bitcoin-$BITCOIND_VERSION-x86_64-linux-gnu.tar.gz && \
+        wget https://adiabat.github.io/bitcoin-$BITCOIND_VERSION-x86_64-linux-gnu.tar.gz && \
         tar xvfz bitcoin-$BITCOIND_VERSION-x86_64-linux-gnu.tar.gz && \
         sudo cp ./bitcoin-$BITCOIND_VERSION/bin/bitcoind /usr/local/bin/bitcoind && \
         sudo cp ./bitcoin-$BITCOIND_VERSION/bin/bitcoin-cli /usr/local/bin/bitcoin-cli && \


### PR DESCRIPTION
This PR should help with faster testing as the server binary can build a small number of proofs, quit, and then start serving them.  Generating the proofs and serving them are pretty independent things and this helps pull them apart.

