### PR TITLE
bridgenode: Don't use compression for leveldb

### DIFF
--- a/bridgenode/genproofs.go
+++ b/bridgenode/genproofs.go
@@ -45,12 +45,14 @@ func BuildProofs(
 		fmt.Printf("not in %s, specify alternate path with -datadir\n.", dataDir)
 		return err
 	}
-	// for testing only
-	// knownTipHeight = 32500
 
 	ttlpath := "utree/" + param.Name + "ttldb"
+
 	// Open leveldb
-	o := opt.Options{CompactionTableSizeMultiplier: 8}
+	o := opt.Options{
+		CompactionTableSizeMultiplier: 8,
+		Compression:                   opt.NoCompression,
+	}
 	lvdb, err := leveldb.OpenFile(ttlpath, &o)
 	if err != nil {
 		fmt.Printf("initialization error.  If your .blk and .dat files are ")

--- a/bridgenode/server.go
+++ b/bridgenode/server.go
@@ -32,8 +32,12 @@ func ArchiveServer(param chaincfg.Params, dataDir string, sig chan bool) error {
 
 	// TODO ****** server shouldn't need levelDB access, fix this
 	ttlpath := "utree/" + param.Name + "ttldb"
+
 	// Open leveldb
-	o := opt.Options{CompactionTableSizeMultiplier: 8}
+	o := opt.Options{
+		CompactionTableSizeMultiplier: 8,
+		Compression:                   opt.NoCompression,
+	}
 	lvdb, err := leveldb.OpenFile(ttlpath, &o)
 	if err != nil {
 		fmt.Printf("initialization error.  If your .blk and .dat files are ")


### PR DESCRIPTION
Leveldb compression is slowing down client serving. I know flatttl is coming but this is a no-brainer simple change that results in massive speedups.
<img width="1185" alt="Screen Shot 2020-09-28 at 8 51 57 PM" src="https://user-images.githubusercontent.com/37185887/94428912-7b636600-01cc-11eb-9ba9-dfae4f810995.png">

We're already giving the same option for rev leveldb https://github.com/mit-dci/utreexo/blob/b3afd5d7a3f0fc297c2ce1d936b6bf87edd6fd61/bridgenode/rev.go#L400