### PR TITLE
Move TTL data to flat file

### DIFF
--- a/bridgenode/genproofs.go
+++ b/bridgenode/genproofs.go
@@ -61,11 +61,11 @@ func BuildProofs(
 
 	// For ttl value writing
 	var batchwg sync.WaitGroup
-	batchan := make(chan *leveldb.Batch, 10)
+	txoWriteBatchan := make(chan *leveldb.Batch, 10)
 
 	// Start 16 workers. Just an arbitrary number
 	for j := 0; j < 16; j++ {
-		go DbWorker(batchan, lvdb, &batchwg)
+		go DbWorker(txoWriteBatchan, lvdb, &batchwg)
 	}
 
 	// To send/receive blocks from blockreader()
@@ -89,7 +89,7 @@ func BuildProofs(
 		bnr := <-blockAndRevReadQueue
 
 		// Writes the ttl values for each tx to leveldb
-		WriteBlock(bnr, batchan, &batchwg)
+		WriteBlock(bnr, txoWriteBatchan, &batchwg)
 
 		// Get the add and remove data needed from the block & undo block
 		blockAdds, delLeaves, err := blockToAddDel(bnr)

--- a/bridgenode/genproofs.go
+++ b/bridgenode/genproofs.go
@@ -61,11 +61,11 @@ func BuildProofs(
 
 	// For ttl value writing
 	var batchwg sync.WaitGroup
-	txoWriteBatchan := make(chan *leveldb.Batch, 10)
+	dbWorkChan := make(chan dbWork, 10)
 
 	// Start 16 workers. Just an arbitrary number
 	for j := 0; j < 16; j++ {
-		go DbWorker(txoWriteBatchan, lvdb, &batchwg)
+		go DbWorker(dbWorkChan, lvdb, &batchwg)
 	}
 
 	// To send/receive blocks from blockreader()
@@ -89,7 +89,7 @@ func BuildProofs(
 		bnr := <-blockAndRevReadQueue
 
 		// Writes the ttl values for each tx to leveldb
-		WriteBlock(bnr, txoWriteBatchan, &batchwg)
+		WriteBlock(bnr, dbWorkChan, &batchwg)
 
 		// Get the add and remove data needed from the block & undo block
 		blockAdds, delLeaves, err := blockToAddDel(bnr)

--- a/bridgenode/genproofs.go
+++ b/bridgenode/genproofs.go
@@ -61,7 +61,7 @@ func BuildProofs(
 
 	// For ttl value writing
 	var batchwg sync.WaitGroup
-	dbWorkChan := make(chan dbWork, 10)
+	dbWorkChan := make(chan ttlBlock, 10)
 
 	// Start 16 workers. Just an arbitrary number
 	for j := 0; j < 16; j++ {

--- a/bridgenode/server.go
+++ b/bridgenode/server.go
@@ -186,20 +186,24 @@ func serveBlocksWorker(
 			}
 
 			// set leaf ttl values
-			ud.LeafTTLs = make([]int32, len(ud.UtxoData))
-			for i, utxo := range ud.UtxoData {
-				heightBytes, err := lvdb.Get(
-					[]byte(util.OutpointToBytes(utxo.Outpoint)), nil)
-				if err != nil {
-					if err == leveldb.ErrNotFound {
-						// outpoint not spend yet, set to a billion for unknown
-						ud.LeafTTLs[i] = 1 << 30
-						continue
+			// now we get them all for free
+
+			/*
+				ud.LeafTTLs = make([]int32, len(ud.UtxoData))
+				for i, utxo := range ud.UtxoData {
+					heightBytes, err := lvdb.Get(
+						[]byte(util.OutpointToBytes(&utxo.Outpoint)), nil)
+					if err != nil {
+						if err == leveldb.ErrNotFound {
+							// outpoint not spend yet, set to a billion for unknown
+							ud.LeafTTLs[i] = 1 << 30
+							continue
+						}
+						panic(err)
 					}
-					panic(err)
+					ud.LeafTTLs[i] = int32(binary.BigEndian.Uint32(heightBytes))
 				}
-				ud.LeafTTLs[i] = int32(binary.BigEndian.Uint32(heightBytes))
-			}
+			*/
 			udb = ud.ToBytes()
 
 			// fmt.Printf("h %d read %d byte udb\n", curHeight, len(udb))

--- a/bridgenode/server.go
+++ b/bridgenode/server.go
@@ -3,7 +3,6 @@ package bridgenode
 import (
 	"encoding/binary"
 	"fmt"
-	"math"
 	"net"
 	"os"
 	"time"
@@ -187,19 +186,19 @@ func serveBlocksWorker(
 			}
 
 			// set leaf ttl values
-			ud.LeafTTLs = make([]uint32, len(ud.UtxoData))
+			ud.LeafTTLs = make([]int32, len(ud.UtxoData))
 			for i, utxo := range ud.UtxoData {
 				heightBytes, err := lvdb.Get(
 					[]byte(util.OutpointToBytes(utxo.Outpoint)), nil)
 				if err != nil {
 					if err == leveldb.ErrNotFound {
-						// outpoint not spend yet, set leaf ttl to max uint32 value
-						ud.LeafTTLs[i] = math.MaxUint32
+						// outpoint not spend yet, set to a billion for unknown
+						ud.LeafTTLs[i] = 1 << 30
 						continue
 					}
 					panic(err)
 				}
-				ud.LeafTTLs[i] = binary.BigEndian.Uint32(heightBytes)
+				ud.LeafTTLs[i] = int32(binary.BigEndian.Uint32(heightBytes))
 			}
 			udb = ud.ToBytes()
 

--- a/bridgenode/server.go
+++ b/bridgenode/server.go
@@ -189,8 +189,8 @@ func serveBlocksWorker(
 			// set leaf ttl values
 			ud.LeafTTLs = make([]uint32, len(ud.UtxoData))
 			for i, utxo := range ud.UtxoData {
-				outpointHash := util.HashFromString(utxo.Outpoint.String())
-				heightBytes, err := lvdb.Get(outpointHash[:], nil)
+				heightBytes, err := lvdb.Get(
+					[]byte(util.OutpointToBytes(utxo.Outpoint)), nil)
 				if err != nil {
 					if err == leveldb.ErrNotFound {
 						// outpoint not spend yet, set leaf ttl to max uint32 value

--- a/bridgenode/ttl.go
+++ b/bridgenode/ttl.go
@@ -6,16 +6,72 @@ import (
 	"os"
 	"sync"
 
+	"github.com/btcsuite/btcd/wire"
+
 	"github.com/mit-dci/utreexo/util"
 
 	"github.com/syndtr/goleveldb/leveldb"
 )
 
+/*
+Here's what it *did*:   (can delete after this is old)
+
+genproof:
+
+Get a block at current height
+Look through txins
+get utxo identifier (outpoint) and current block height
+write outpoint: deathheight to db (current height is deathheight)
+
+serve:
+
+Get a block at current height
+look through all the outputs and calculate outpoint
+lookup outpoints in DB and get deathheight
+subtract deathheight from current height, get duration for the new utxo
+
+That's bad!  Because you're doing lots o fDB lookups when serving which is slow,
+and you're keepting a big DB of every txo ever.
+
+--------------------------------------------------
+
+Here's what it *does* now:
+
+genproof:
+
+Get a block at current height:
+
+look through txouts, put those in DB.  Also put their place in the block
+db key: outpoint db value: txoinblock index (4 bytes)
+
+also look through txins.  for each of them, look them up in the db,
+getting the birthheight and which txo it is within that block.
+lookup the block offset where the txo was created, seek to that block,
+then seek the the 4 byte location where its duration is stored (starts as
+unknown / 0 / -1 whatever) and overwrite it.
+
+Also delete the db entry for the txin.
+And yeah this is a utxo db so if we put more data here, then we don't
+need the rev files... and if the rev files told which txout in the block it
+was... we wouldn't need a db at all.
+
+serve:
+
+Get a block at current height
+all the ttl values are right there in the block, nothing to do
+
+That's better, do more work in genproofs since that only happens once and
+serving can happen lots of times.
+
+
+*/
+
 // the thing we send to the dbWorker; a db batch and some ttl results
-type dbWork struct {
-	blockHeight int32
-	ttldata     []TTLResult
-	batch       *leveldb.Batch
+type ttlBlock struct {
+	blockHeight       int32
+	newTxos           [][36]byte
+	spentTxos         [][36]byte
+	spentStartHeights []int32
 }
 
 // a TTLResult is the TTL data we learn once a txo is spent & it's lifetime
@@ -28,48 +84,40 @@ type TTLResult struct {
 	//  ^^^ could be uint16 since there can't be 65K txos in a block
 }
 
-// WriteBlock sends off ttl info to dbWorker to be written to ttldb
-func WriteBlock(bnr BlockAndRev,
-	batchan chan dbWork, wg *sync.WaitGroup) {
-
-	blockBatch := new(leveldb.Batch)
-	var work dbWork
+// WriteBlock sends off TTL-related data to dbWorker to be written to ttldb and
+// looked up for insertion into the flat file
+func WriteBlock(bnr BlockAndRev, batchan chan ttlBlock, wg *sync.WaitGroup) {
+	var work ttlBlock
 	work.blockHeight = bnr.Height
-	// write key:value to the ttl db; key is 8 bytes blockheight, txoutnumber
-	var txoInBlock uint32
+
 	// iterate through the transactions in a block
-	for blockindex, tx := range bnr.Blk.Transactions {
-		// iterate through individual inputs in a transaction
-		for _, in := range tx.TxIn {
-			if blockindex > 0 { // skip coinbase "spend"
-				heightBytes := make([]byte, 4)
-				binary.BigEndian.PutUint32(
-					heightBytes,
-					uint32(bnr.Height+1), // why +1??
-				)
-				// TODO ^^^^^ yeah why
-				blockBatch.Put(
-					util.OutpointToBytes(in.PreviousOutPoint), heightBytes)
+	for txInBlock, tx := range bnr.Blk.Transactions {
+		txid := tx.TxHash()
+
+		// for all the txouts, get their outpoint & index and throw that into
+		// a db batch
+		for txoInTx, _ := range tx.TxOut {
+			work.newTxos = append(work.newTxos,
+				util.OutpointToBytes(wire.NewOutPoint(&txid, uint32(txoInTx))))
+
+			// for all the txins, throw that into the work as well; just a bunch of
+			// outpoints
+
+			for txinInTx, in := range tx.TxIn {
+				if txInBlock == 0 {
+					break // skip coinbase input
+				}
+				// append outpoint to slice
+				work.spentTxos = append(work.spentTxos,
+					util.OutpointToBytes(&in.PreviousOutPoint))
+				// append start height to slice (get from rev data)
+				work.spentStartHeights = append(work.spentStartHeights,
+					bnr.Rev.Txs[txInBlock].TxIn[txinInTx].Height)
 			}
-		}
-		for _, out := range tx.TxOut {
-
-			var result TTLResult
-
-			// look up start height for this txin in db
-			result.StartHeight = 1 // from db
-			result.Duration = bnr.Height - result.StartHeight
-			result.TxoNumInBlock = txoInBlock
-
-			work.ttldata = append(work.ttldata)
-
-			txoInBlock++
 		}
 	}
 
 	wg.Add(1)
-
-	work.batch = blockBatch
 	// send to dbworker to be written to ttldb asynchronously
 	batchan <- work
 }
@@ -77,7 +125,7 @@ func WriteBlock(bnr BlockAndRev,
 // DbWorker writes everything to the db. It's it's own goroutine so it
 // can work at the same time that the reads are happening
 func DbWorker(
-	dbWorkChan chan dbWork, lvdb *leveldb.DB, wg *sync.WaitGroup) {
+	dbWorkChan chan ttlBlock, lvdb *leveldb.DB, wg *sync.WaitGroup) {
 
 	// open the offsetFile read-only
 	offsetFile, err := os.Open(util.POffsetFilePath)
@@ -85,25 +133,91 @@ func DbWorker(
 		panic(err)
 	}
 
+	val := make([]byte, 4)
+	offsetBytes := make([]byte, 8)
+
 	for {
 		work := <-dbWorkChan
-		err := lvdb.Write(b, nil)
+		var batch leveldb.Batch
+		// build the batch for writing to levelDB.
+		// Just outpoints to index in block
+		for i, op := range work.newTxos {
+			binary.BigEndian.PutUint32(val, uint32(i))
+			batch.Put(op[:], val)
+		}
+		// write all the new utxos in the batch to the DB
+		err := lvdb.Write(&batch, nil)
 		if err != nil {
 			fmt.Println(err.Error())
 		}
-		ttlRes := <-ttlChan
-		// make sure that the offset file has been written to for this block
-		stat, err := offsetFile.Stat()
-		// for stat.Size() <
+		batch.Reset()
 
+		inBlockIdxs := make([]uint32, len(work.spentTxos))
+		// now read from the DB all the spent txos and find their
+		// position within their creation block
+		for i, op := range work.spentTxos {
+			batch.Delete(op[:]) // add this outpoint for deletion
+			idxBytes, err := lvdb.Get(op[:], nil)
+			if err != nil {
+				panic(err)
+			}
+			inBlockIdxs[i] = binary.BigEndian.Uint32(idxBytes)
+		}
+		// delete all the old outpoints
+		err = lvdb.Write(&batch, nil)
 		if err != nil {
-			fmt.Printf("DbWorker error stating offsetfile\n")
-			panic(err)
-		}
-		for _, result := range ttlRes {
-			blockStartLoc, err := offsetFile.Seek(int64(result.StartHeight)*8, 0)
+			fmt.Println(err.Error())
 		}
 
+		// make sure that the offset file has been written to for this block
+		// we might not be writing to things that recent but usually are, so
+		// wait for the flatfile to be created before we start writing.
+		// usually this will have already happened I think
+		// stat, err := offsetFile.Stat()
+		// if err != nil {
+		// 	fmt.Printf("DbWorker error stating offsetfile\n")
+		// 	panic(err)
+		// }
+		// for stat.Size() < work.blockHeight*8 {
+		// 	stat, err := offsetFile.Stat()
+		// }
+
+		// open the proof file for writing.  Guess we have to fight with
+		// proofWriterWorker() for this?  Or maybe we can give commands over the
+		// channel to proofWriterWorker()
+
+		// TODO ok yeah I think it's better to expand proofWriterWorker() to
+		// absorb some of this data because it's got the proof file under its
+		// control and it seems easier to let it be the only one writing to that
+
+		// proofFile, err := os.OpenFile(
+		// util.PFilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+		// if err != nil {
+		// panic(err)
+		// }
+
+		// offsetFile, err := os.Open(util.POffsetFilePath)
+		// if err != nil {
+		// 	panic(err)
+		// }
+
+		// ssh is spent start height.  blockheight-ssh is the utxo duration
+		// range through every spent txo here, look up the block they were
+		// created in, seek to that block plus the index of that txo creation
+		// then write the duration value
+		for _, ssh := range work.spentStartHeights {
+
+			// look up this utxo's creation block offset
+			_, err := offsetFile.ReadAt(offsetBytes, int64(ssh)*8)
+			if err != nil {
+				panic(err)
+			}
+			// blockStartOffset = int64(binary.BigEndian.Uint64(offsetBytes))
+
+			binary.Write(offsetFile, binary.BigEndian, work.blockHeight-ssh)
+
+			// work.blockHeight-ssh
+		}
 		wg.Done()
 	}
 }

--- a/bridgenode/ttl.go
+++ b/bridgenode/ttl.go
@@ -3,6 +3,7 @@ package bridgenode
 import (
 	"encoding/binary"
 	"fmt"
+	"os"
 	"sync"
 
 	"github.com/mit-dci/utreexo/util"
@@ -10,23 +11,32 @@ import (
 	"github.com/syndtr/goleveldb/leveldb"
 )
 
-// DeathInfo is needed to asynchronously read from the leveldb
-// Insures that the TxOs are in order
-type DeathInfo struct {
-	// DeathHeight is where the TxOs are spent
-	// TxPos is the index within the TX
-	DeathHeight, TxPos int32
-	Txid               [32]byte
+// the thing we send to the dbWorker; a db batch and some ttl results
+type dbWork struct {
+	blockHeight int32
+	ttldata     []TTLResult
+	batch       *leveldb.Batch
+}
+
+// a TTLResult is the TTL data we learn once a txo is spent & it's lifetime
+// can be written to its creation ublock
+// When writing to the flat file, you want to seek to StartHeight, skip to
+// the TxoNumInBlock'th entry, and write Duration
+type TTLResult struct {
+	StartHeight, Duration int32
+	TxoNumInBlock         uint32
+	//  ^^^ could be uint16 since there can't be 65K txos in a block
 }
 
 // WriteBlock sends off ttl info to dbWorker to be written to ttldb
 func WriteBlock(bnr BlockAndRev,
-	batchan chan *leveldb.Batch, wg *sync.WaitGroup) {
+	batchan chan dbWork, wg *sync.WaitGroup) {
 
 	blockBatch := new(leveldb.Batch)
-
+	var work dbWork
+	work.blockHeight = bnr.Height
 	// write key:value to the ttl db; key is 8 bytes blockheight, txoutnumber
-
+	var txoInBlock uint32
 	// iterate through the transactions in a block
 	for blockindex, tx := range bnr.Blk.Transactions {
 		// iterate through individual inputs in a transaction
@@ -42,24 +52,58 @@ func WriteBlock(bnr BlockAndRev,
 					util.OutpointToBytes(in.PreviousOutPoint), heightBytes)
 			}
 		}
+		for _, out := range tx.TxOut {
+
+			var result TTLResult
+
+			// look up start height for this txin in db
+			result.StartHeight = 1 // from db
+			result.Duration = bnr.Height - result.StartHeight
+			result.TxoNumInBlock = txoInBlock
+
+			work.ttldata = append(work.ttldata)
+
+			txoInBlock++
+		}
 	}
+
 	wg.Add(1)
 
+	work.batch = blockBatch
 	// send to dbworker to be written to ttldb asynchronously
-	batchan <- blockBatch
+	batchan <- work
 }
 
 // DbWorker writes everything to the db. It's it's own goroutine so it
 // can work at the same time that the reads are happening
 func DbWorker(
-	bChan chan *leveldb.Batch, lvdb *leveldb.DB, wg *sync.WaitGroup) {
+	dbWorkChan chan dbWork, lvdb *leveldb.DB, wg *sync.WaitGroup) {
+
+	// open the offsetFile read-only
+	offsetFile, err := os.Open(util.POffsetFilePath)
+	if err != nil {
+		panic(err)
+	}
 
 	for {
-		b := <-bChan
+		work := <-dbWorkChan
 		err := lvdb.Write(b, nil)
 		if err != nil {
 			fmt.Println(err.Error())
 		}
+		ttlRes := <-ttlChan
+		// make sure that the offset file has been written to for this block
+		stat, err := offsetFile.Stat()
+		// for stat.Size() <
+
+		if err != nil {
+			fmt.Printf("DbWorker error stating offsetfile\n")
+			panic(err)
+		}
+		for _, result := range ttlRes {
+			blockStartLoc, err := offsetFile.Seek(int64(result.StartHeight)*8, 0)
+		}
+
 		wg.Done()
 	}
 }

--- a/bridgenode/ttl.go
+++ b/bridgenode/ttl.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/mit-dci/utreexo/util"
+
 	"github.com/syndtr/goleveldb/leveldb"
 )
 
@@ -24,20 +25,21 @@ func WriteBlock(bnr BlockAndRev,
 
 	blockBatch := new(leveldb.Batch)
 
+	// write key:value to the ttl db; key is 8 bytes blockheight, txoutnumber
+
 	// iterate through the transactions in a block
 	for blockindex, tx := range bnr.Blk.Transactions {
 		// iterate through individual inputs in a transaction
 		for _, in := range tx.TxIn {
 			if blockindex > 0 { // skip coinbase "spend"
-				opString := in.PreviousOutPoint.String()
-				h := util.HashFromString(opString)
 				heightBytes := make([]byte, 4)
 				binary.BigEndian.PutUint32(
 					heightBytes,
 					uint32(bnr.Height+1), // why +1??
 				)
 				// TODO ^^^^^ yeah why
-				blockBatch.Put(h[:], heightBytes)
+				blockBatch.Put(
+					util.OutpointToBytes(in.PreviousOutPoint), heightBytes)
 			}
 		}
 	}

--- a/util/utils.go
+++ b/util/utils.go
@@ -183,11 +183,10 @@ func GetUDataBytesFromFile(height int32) (b []byte, err error) {
 	return
 }
 
-func OutpointToBytes(op wire.OutPoint) []byte {
-	var buf bytes.Buffer
-	_, _ = buf.Write(op.Hash[:])
-	binary.Write(&buf, binary.BigEndian, op.Index)
-	return buf.Bytes()
+func OutpointToBytes(op *wire.OutPoint) (b [36]byte) {
+	copy(b[0:32], op.Hash[:])
+	binary.BigEndian.Uint32(b[32:36])
+	return
 }
 
 // BlockToAdds turns all the new utxos in a msgblock into leafTxos

--- a/util/utils.go
+++ b/util/utils.go
@@ -112,7 +112,7 @@ func UblockNetworkReader(
 			return
 		}
 
-		ub.Height = curHeight
+		ub.UtreexoData.Height = curHeight
 		blockChan <- ub
 	}
 }

--- a/util/utils.go
+++ b/util/utils.go
@@ -183,6 +183,13 @@ func GetUDataBytesFromFile(height int32) (b []byte, err error) {
 	return
 }
 
+func OutpointToBytes(op wire.OutPoint) []byte {
+	var buf bytes.Buffer
+	_, _ = buf.Write(op.Hash[:])
+	binary.Write(&buf, binary.BigEndian, op.Index)
+	return buf.Bytes()
+}
+
 // BlockToAdds turns all the new utxos in a msgblock into leafTxos
 // uses remember slice up to number of txos, but doesn't check that it's the
 // right length.  Similar with skiplist, doesn't check it.


### PR DESCRIPTION
This gets rid of levelDB for the server by putting the TTL data into the flat file with the proofs.