### PR TITLE
accumulator: Fix batch proof verification

### DIFF
--- a/accumulator/batchproof.go
+++ b/accumulator/batchproof.go
@@ -251,10 +251,13 @@ func verifyBatchProof(bp BatchProof, roots []Hash, numLeaves uint64,
 
 		// get the hash of the parent from the cache or compute it
 		parentPos := parent(target.Pos, rows)
-		isParentCached, hash := cached(parentPos)
-		if !isParentCached {
-			hash = parentHash(left.Val, right.Val)
+		isParentCached, cachedHash := cached(parentPos)
+		hash := parentHash(left.Val, right.Val)
+		if isParentCached && hash != cachedHash {
+			// The hash did not match the cached hash
+			return false, nil, nil
 		}
+
 		trees = append(trees, [3]node{{Val: hash, Pos: parentPos}, left, right})
 
 		row := detectRow(parentPos, rows)

--- a/accumulator/pollard_test.go
+++ b/accumulator/pollard_test.go
@@ -33,6 +33,33 @@ func TestPollardFixed(t *testing.T) {
 	}
 }
 
+func TestPollardSimpleIngest(t *testing.T) {
+	f := NewForest(nil, false, "", 0)
+	adds := make([]Leaf, 15)
+	for i := 0; i < len(adds); i++ {
+		adds[i].Hash[0] = uint8(i + 1)
+	}
+
+	f.Modify(adds, []uint64{})
+	fmt.Println(f.ToString())
+
+	hashes := make([]Hash, len(adds))
+	for i := 0; i < len(hashes); i++ {
+		hashes[i] = adds[i].Hash
+	}
+
+	bp, _ := f.ProveBatch(hashes)
+
+	var p Pollard
+	p.Modify(adds, nil)
+	// Modify the proof so that the verification should fail.
+	bp.Proof[0][0] = 0xFF
+	err := p.IngestBatchProof(bp)
+	if err == nil {
+		t.Fatal("BatchProof valid after modification. Accumulator validation failing")
+	}
+}
+
 func pollardRandomRemember(blocks int32) error {
 
 	// ffile, err := os.Create("/dev/shm/forfile")


### PR DESCRIPTION
See commit message for explanation.

I checked with the previous map based verification and the same problem existed there:
https://github.com/mit-dci/utreexo/blob/573edd2bb6d34f7073873e617c13c056e745d658/accumulator/pollardproof.go#L177-L194

`parhash` is considered to be equal to the result of `parentHash(...)`.

The main problem here is that the roots are always cached and therefore the roots computed from the proof are never actually compared to the actual roots. 