### PR TITLE
Fix bridge restart

### DIFF
--- a/bridgenode/flatfileworker.go
+++ b/bridgenode/flatfileworker.go
@@ -158,6 +158,10 @@ func (ff *flatFileState) ffInit() error {
 			ff.offsets[ff.currentHeight] = ff.currentOffset
 			ff.currentHeight++
 		}
+
+		// set currentOffset to the end of the proof file
+		ff.currentOffset, _ = ff.proofFile.Seek(0, 2)
+
 	} else { // first time startup
 		// there is no block 0 so leave that empty
 		fmt.Printf("setting h=1\n")

--- a/bridgenode/flatfileworker.go
+++ b/bridgenode/flatfileworker.go
@@ -229,6 +229,7 @@ func (ff *flatFileState) writeProofBlock(ud util.UData) error {
 	ff.currentOffset += int64(ud.SerializeSize()) + 8
 	ff.currentHeight++
 
+	ff.fileWait.Done()
 	// fmt.Printf("flatFileBlockWorker h %d wrote %d bytes to offset %d\n",
 	// ff.currentHeight, ud.SerializeSize()+8, ff.currentOffset)
 	return nil

--- a/bridgenode/genproofs.go
+++ b/bridgenode/genproofs.go
@@ -133,7 +133,7 @@ func BuildProofs(
 		// start waitgroups, beyond this point we have to finish all the
 		// disk writes for this iteration of the loop
 		dbwg.Add(1)     // DbWorker calls Done()
-		fileWait.Add(1) // flatFileWorker calls Done() (when done writing ttls)
+		fileWait.Add(2) // flatFileWorker calls Done() when done writing ttls and proof.
 
 		// Writes the new txos to leveldb,
 		// and generates TTL for txos spent in the block

--- a/util/types.go
+++ b/util/types.go
@@ -219,7 +219,7 @@ func (ud *UData) Deserialize(r io.Reader) (err error) {
 	}
 	// fmt.Printf("read height %d\n", ud.Height)
 
-	var numTTLs int32
+	var numTTLs uint32
 	err = binary.Read(r, binary.BigEndian, &numTTLs)
 	if err != nil { // ^ 4B num ttls
 		fmt.Printf("ud deser numTTLs err %s\n", err.Error())


### PR DESCRIPTION
The offset of the last written proof was saved which caused an off-by-one on restart because that last proof is over written by the next block.

Closes #216 