### PR TITLE
.github/go.yml: Update Github Actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,8 +10,8 @@ jobs:
     - name: setup env
       shell: bash
       run: |
-        echo "::set-env name=GOPATH::${{ github.workspace }}/go"
-        echo "::add-path::${{ github.workspace }}/go/bin"
+        echo "${{ github.workspace }}/go/bin:" >> $GITHUB_PATH
+        echo "GOPATH=${{ github.workspace }}/go" >> $GITHUB_ENV
 
     - name: Install Go
       if: success()


### PR DESCRIPTION
Github is deprecating 'add-path' and 'set-env' because of vulnerabilities.
Updates to the new recommended functions.

More info [here](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) about the deprecation