### PR TITLE
accumulator: Check number of proof hashes

### DIFF
--- a/accumulator/batchproof.go
+++ b/accumulator/batchproof.go
@@ -159,6 +159,12 @@ func verifyBatchProof(bp BatchProof, roots []Hash, numLeaves uint64,
 	rows := treeRows(numLeaves)
 	proofPositions, computablePositions :=
 		ProofPositions(targets, numLeaves, rows)
+
+	// The proof should have as many hashes as there are proof positions.
+	if len(proofPositions)+len(bp.Targets) != len(bp.Proof) {
+		return false, nil, nil
+	}
+
 	// targetNodes holds nodes that are known, on the bottom row those
 	// are the targets, on the upper rows it holds computed nodes.
 	// rootCandidates holds the roots that where computed, and have to be

--- a/accumulator/batchproof_test.go
+++ b/accumulator/batchproof_test.go
@@ -5,6 +5,47 @@ import (
 	"testing"
 )
 
+// TestIncompleteBatchProof tests that a incomplete (missing some hashes) batchproof does not pass verification.
+func TestIncompleteBatchProof(t *testing.T) {
+	// Create forest in memory
+	f := NewForest(nil, false, "", 0)
+
+	// last index to be deleted. Same as blockDels
+	lastIdx := uint64(7)
+
+	// Generate adds
+	adds := make([]Leaf, 8)
+	adds[0].Hash = Hash{1}
+	adds[1].Hash = Hash{2}
+	adds[2].Hash = Hash{3}
+	adds[3].Hash = Hash{4}
+	adds[4].Hash = Hash{5}
+	adds[5].Hash = Hash{6}
+	adds[6].Hash = Hash{7}
+	adds[7].Hash = Hash{8}
+
+	// Modify with the additions to simulate txos being added
+	_, err := f.Modify(adds, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// create blockProof based on the last add in the slice
+	blockProof, err := f.ProveBatch(
+		[]Hash{adds[lastIdx].Hash})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	blockProof.Proof = blockProof.Proof[:len(blockProof.Proof)-1]
+	shouldBeFalse := f.VerifyBatchProof(blockProof)
+	if shouldBeFalse != false {
+		t.Fail()
+		t.Logf("Incomplete proof passes verification")
+	}
+}
+
 // TestVerifyBlockProof tests that the computedTop is compared to the top in the
 // Utreexo forest.
 func TestVerifyBatchProof(t *testing.T) {


### PR DESCRIPTION
If the number of proof positions (+number of targets) does not match the number of provided hashes the proof is invalid.