### PR TITLE
csn: Use ttl not ttl - height

### DIFF
--- a/csn/ibd.go
+++ b/csn/ibd.go
@@ -184,7 +184,7 @@ func (c *Csn) putBlockInPollard(
 	remember := make([]bool, len(ub.UtreexoData.TxoTTLs))
 	for i, ttl := range ub.UtreexoData.TxoTTLs {
 		// ttl-ub.Height is the number of blocks until the block is spend.
-		remember[i] = ttl-ub.UtreexoData.Height < c.pollard.Lookahead
+		remember[i] = ttl < c.pollard.Lookahead
 	}
 
 	// get hashes to add into the accumulator


### PR DESCRIPTION
The ttl values being send now are actually the ttls not heights, so the
subtraction is not needed anymore.

Also @adiabat since the verification logic got changed the `overWire` variable is currently not used but the place to collect the positions for the playbooks would be in the **else** branch [here](https://github.com/mit-dci/utreexo/blob/760cec1adc9aceb112ed16e6343ee06135e098a8/accumulator/pollardproof.go#L78) and [here](https://github.com/mit-dci/utreexo/blob/760cec1adc9aceb112ed16e6343ee06135e098a8/accumulator/pollardproof.go#L86). 
`p.populate` is called for every root that was involved in the verification, so what you need to do to get all the "overwire" positions for the entire proof is: collect the "overwire" positions in each populate call and then concat all these together, sort them and store them in the playbook file.
