### PR TITLE
accumulator/hasher.go: Faster hashrow

### DIFF
--- a/accumulator/hasher.go
+++ b/accumulator/hasher.go
@@ -6,32 +6,11 @@ type hashableNode struct {
 	position  uint64 // doesn't really need to be there, but convenient for debugging
 }
 
-type hashNpos struct {
-	result Hash
-	pos    uint64
-}
-
-func hashOne(l, r Hash, p uint64, hchan chan hashNpos) {
-	var hnp hashNpos
-	hnp.pos = p
-	hnp.result = parentHash(l, r)
-	hchan <- hnp
-}
-
 func (f *Forest) hashRow(dirtpositions []uint64) error {
-
-	hchan := make(chan hashNpos, 256) // probably don't need that big a buffer
-
 	for _, hp := range dirtpositions {
 		l := f.data.read(child(hp, f.rows))
 		r := f.data.read(child(hp, f.rows) | 1)
-		// fmt.Printf("hash pos %d l %x r %x\n", hp, l[:4], r[:4])
-		go hashOne(l, r, hp, hchan)
-	}
-
-	for remaining := len(dirtpositions); remaining > 0; remaining-- {
-		hnp := <-hchan
-		f.data.write(hnp.pos, hnp.result)
+		f.data.write(hp, parentHash(l, r))
 	}
 
 	return nil


### PR DESCRIPTION
EDIT: sha512 was not the culprit, it was the goroutines.

`hashOne()` was taking up 22% of the overall sync time from my tests up to height `150,000` on mainnet.
<img width="1549" alt="Screen Shot 2020-11-12 at 5 33 41 PM" src="https://user-images.githubusercontent.com/37185887/98916046-0941a900-250e-11eb-842a-df968190ea4f.png">

This slowdown is mostly caused by the heap allocations that each of the goroutine makes. Each makes 4096bytes of stack so over time this builds up a lot. Solution was to just get rid of the goroutines.

Profiling for the new code looks like so. `root` takes 142.15 seconds. Note how long the `hashRow()` function takes. This is with the individual hashes counting towards the overall time (since there is no more goroutines).
<img width="1593" alt="Screen Shot 2020-11-12 at 5 34 41 PM" src="https://user-images.githubusercontent.com/37185887/98916496-9553d080-250e-11eb-935f-f3ac603dc0a5.png">


Compared to the old profile here, where the `root` takes 250.44 seconds. Note how the `hashRow()` function takes longer, not counting the actual individual hashes.
<img width="1553" alt="Screen Shot 2020-11-12 at 5 34 30 PM" src="https://user-images.githubusercontent.com/37185887/98916499-97b62a80-250e-11eb-87b3-70e1ef1d8ab7.png">