### PR TITLE
WIP: Faster row hashing during delete

### DIFF
--- a/accumulator/hasher.go
+++ b/accumulator/hasher.go
@@ -1,17 +1,83 @@
 package accumulator
 
+import (
+	"fmt"
+	"runtime"
+	"sync"
+)
+
+// The min number of hashes a hashWorker receives.
+const MinHashesPerWorker = 100
+
+// Used to pass slices of hashwork to the hash workers.
+var hashWorkChan chan []*hashWork
+var hashWorkWg *sync.WaitGroup
+
 // hashableNode is the data needed to perform a hash
 type hashableNode struct {
 	sib, dest *polNode
 	position  uint64 // doesn't really need to be there, but convenient for debugging
 }
 
-func (f *Forest) hashRow(dirtpositions []uint64) error {
-	for _, hp := range dirtpositions {
-		l := f.data.read(child(hp, f.rows))
-		r := f.data.read(child(hp, f.rows) | 1)
-		f.data.write(hp, parentHash(l, r))
+type hashWork struct {
+	left, right, parent Hash
+}
+
+func hashWorker() {
+	for {
+		work, ok := <-hashWorkChan
+		if !ok {
+			return
+		}
+
+		for _, w := range work {
+			w.parent = parentHash(w.left, w.right)
+		}
+
+		hashWorkWg.Done()
+	}
+}
+
+var maxHashesPerRoutine int
+var avgHashesPerRoutine int
+var count int
+
+func hashRow(work []*hashWork) {
+	if count != 0 && count%10000 == 0 {
+		fmt.Println("hasRow:", maxHashesPerRoutine, float32(avgHashesPerRoutine)/float32(count))
 	}
 
-	return nil
+	numRoutines := runtime.NumCPU()
+	workPerRoutine := len(work) / numRoutines
+	if workPerRoutine > maxHashesPerRoutine {
+		maxHashesPerRoutine = workPerRoutine
+	}
+	avgHashesPerRoutine += workPerRoutine
+	count++
+
+	if workPerRoutine < MinHashesPerWorker {
+		// do hashes in sync because the scheduling overhead is not worth it
+		// for a hand full of hashes.
+		for _, w := range work {
+			w.parent = parentHash(w.left, w.right)
+		}
+		return
+	}
+
+	// Split up the work load across numRoutines go routines.
+	for i := 0; i < numRoutines && workPerRoutine > 0; i++ {
+		hashWorkWg.Add(1)
+		hashWorkChan <- work[i*workPerRoutine : (i+1)*workPerRoutine]
+	}
+
+	// Hash the rest
+	workRest := len(work) % numRoutines
+	if workRest > 0 {
+		hashWorkWg.Add(1)
+		hashWorkChan <- work[len(work)-workRest:]
+	}
+
+	if workPerRoutine > 0 || workRest > 0 {
+		hashWorkWg.Wait()
+	}
 }

--- a/accumulator/utils_test.go
+++ b/accumulator/utils_test.go
@@ -5,6 +5,22 @@ import (
 	"testing"
 )
 
+func BenchmarkRowHasherSequential(b *testing.B) {
+	work := make([]*hashWork, b.N)
+	for i := 0; i < len(work); i++ {
+		work[i] = &hashWork{left: Hash{0x1}, right: Hash{0x1}}
+	}
+	hashWorker(work, nil)
+}
+
+func BenchmarkRowHasherParallel(b *testing.B) {
+	work := make([]*hashWork, b.N)
+	for i := 0; i < len(work); i++ {
+		work[i] = &hashWork{left: Hash{0x1}, right: Hash{0x1}}
+	}
+	hashRow(work)
+}
+
 func TestTreeRows(t *testing.T) {
 	// Test all the powers of 2
 	for i := uint8(1); i <= 63; i++ {


### PR DESCRIPTION
Benchmarks indicate that this is worth it:
```
$ go test -bench=RowHasher. -run=Bench
goos: darwin
goarch: amd64
pkg: github.com/mit-dci/utreexo/accumulator
BenchmarkRowHasherSequential-4           1876930               600 ns/op
BenchmarkRowHasherParallel-4             3982798               335 ns/op
PASS
ok      github.com/mit-dci/utreexo/accumulator  4.349s
```