### PR TITLE
cow: Make sure to close files after use

### DIFF
--- a/accumulator/forestdata.go
+++ b/accumulator/forestdata.go
@@ -197,6 +197,7 @@ func (m *manifest) commit(basePath string) error {
 
 	// Create new manifest on disk
 	fNewManifest, err := os.OpenFile(fPath, os.O_CREATE|os.O_RDWR, 0666)
+	defer fNewManifest.Close()
 	if err != nil {
 		return err
 	}
@@ -279,6 +280,7 @@ func (m *manifest) commit(basePath string) error {
 	// Overwrite the current manifest number in CURRENT
 	curFileName := filepath.Join(basePath, "CURRENT")
 	fCurrent, err := os.OpenFile(curFileName, os.O_CREATE|os.O_WRONLY, 0666)
+	defer fCurrent.Close()
 	if err != nil {
 		return err
 	}
@@ -307,6 +309,7 @@ func (m *manifest) load(path string) error {
 	curFileName := filepath.Join(path, "CURRENT")
 
 	curFile, err := os.OpenFile(curFileName, os.O_RDONLY, 0666)
+	defer curFile.Close()
 	if err != nil {
 		return err
 	}
@@ -331,6 +334,7 @@ func (m *manifest) load(path string) error {
 	}
 
 	maniFile, err := os.Open(maniFilePath)
+	defer maniFile.Close()
 	if err != nil {
 		return err
 	}
@@ -977,6 +981,7 @@ func (cow *cowForest) load(fileNum uint64) error {
 		fmt.Println("FILE LOADED: ", fName)
 	}
 	f, err := os.Open(fName)
+	defer f.Close()
 	if err != nil {
 		// If the error returned is of no files existing, then the manifest
 		// is corrupt
@@ -1083,6 +1088,8 @@ func (cow *cowForest) commit() error {
 		if err != nil {
 			return err
 		}
+
+		f.Close()
 	}
 
 	err := cow.manifest.commit(cow.meta.fBasePath)


### PR DESCRIPTION
I ran into this on the test server:
```
panic: open /home/niklas/go/src/github.com/mit-dci/utreexo/cmd/utreexoserver/utree/forestdata/cow/56956.ufod: too many open files

goroutine 1 [running]:
github.com/mit-dci/utreexo/accumulator.(*cowForest).read(0xc00010e1b0, 0x3da0000, 0x0, 0x0, 0x0, 0x0)
        /home/niklas/go/src/github.com/mit-dci/utreexo/accumulator/forestdata.go:715 +0x529
github.com/mit-dci/utreexo/accumulator.(*Forest).reMap(0xc000012840, 0x981f1a, 0x20, 0xc0b33ce800)
        /home/niklas/go/src/github.com/mit-dci/utreexo/accumulator/forest.go:530 +0x311
github.com/mit-dci/utreexo/accumulator.(*Forest).Modify(0xc000012840, 0xc0cda4e000, 0x4c1e, 0x5b26, 0xc0c8ae6c00, 0x15f, 0x15f, 0x15f, 0x15f, 0xc0cdbcc000)
        /home/niklas/go/src/github.com/mit-dci/utreexo/accumulator/forest.go:466 +0x1ff
github.com/mit-dci/utreexo/bridgenode.BuildProofs(0xc0000ba500, 0xc0004441c0, 0x0, 0x0)
        /home/niklas/go/src/github.com/mit-dci/utreexo/bridgenode/genproofs.go:154 +0x9ad
github.com/mit-dci/utreexo/bridgenode.Start(0xc0000ba500, 0xc0004441c0, 0xc0004441c0, 0xc0000ba500)
        /home/niklas/go/src/github.com/mit-dci/utreexo/bridgenode/server.go:42 +0x16b
main.main()
        /home/niklas/go/src/github.com/mit-dci/utreexo/cmd/utreexoserver/bridgeserver.go:27 +0x1b4
```
