### PR TITLE
accumulator: Change getRootsReverse to getRootsForwards and add a freelist for positionlist

### DIFF
--- a/accumulator/batchproof.go
+++ b/accumulator/batchproof.go
@@ -279,7 +279,7 @@ func verifyBatchProof(bp BatchProof, roots []Hash, numLeaves uint64,
 		if targets[0] == numLeaves-1 && numLeaves&1 == 1 {
 			// target is the row 0 root, append it to the root candidates.
 			rootCandidates = append(rootCandidates,
-				node{Val: roots[0], Pos: targets[0]})
+				node{Val: roots[len(roots)-1], Pos: targets[0]})
 			bp.Proof = bp.Proof[1:]
 			break
 		}
@@ -375,9 +375,9 @@ func verifyBatchProof(bp BatchProof, roots []Hash, numLeaves uint64,
 	// holds a subset of the roots
 	// we count the roots that match in order.
 	rootMatches := 0
-	for _, root := range roots {
+	for i, _ := range roots {
 		if len(rootCandidates) > rootMatches &&
-			root == rootCandidates[rootMatches].Val {
+			roots[len(roots)-(i+1)] == rootCandidates[rootMatches].Val {
 			rootMatches++
 		}
 	}
@@ -416,6 +416,7 @@ func (bp *BatchProof) Reconstruct(
 	if len(proofPositions) != len(bp.Proof) {
 		return nil, fmt.Errorf("Reconstruct wants %d hashes, has %d",
 			len(proofPositions), len(bp.Proof))
+
 	}
 
 	for i, pos := range proofPositions {

--- a/accumulator/forestproofs.go
+++ b/accumulator/forestproofs.go
@@ -177,8 +177,12 @@ func (f *Forest) ProveBatch(hs []Hash) (BatchProof, error) {
 	copy(sortedTargets, bp.Targets)
 	sortUint64s(sortedTargets)
 
-	proofPositions, _ := ProofPositions(sortedTargets, f.numLeaves, f.rows)
-	targetsAndProof := mergeSortedSlices(proofPositions, sortedTargets)
+	positionList := NewPositionList()
+	defer positionList.Free()
+
+	ProofPositions(sortedTargets, f.numLeaves, f.rows, &positionList.list)
+	targetsAndProof := mergeSortedSlices(positionList.list, sortedTargets)
+
 	bp.Proof = make([]Hash, len(targetsAndProof))
 	for i, proofPos := range targetsAndProof {
 		bp.Proof[i] = f.data.read(proofPos)

--- a/accumulator/pollard.go
+++ b/accumulator/pollard.go
@@ -269,17 +269,21 @@ func (p *Pollard) rem2(dels []uint64) error {
 		// fmt.Printf("done with row %d %s\n", h, p.toString())
 	}
 
+	// fmt.Printf("preroot %s", p.toString())
+	positionList := NewPositionList()
+	defer positionList.Free()
+
 	// set new roots
-	nextRootPositions, _ := getRootsForwards(nextNumLeaves, ph)
-	nextRoots := make([]*polNode, len(nextRootPositions))
+	getRootsForwards(nextNumLeaves, ph, &positionList.list)
+	nextRoots := make([]*polNode, len(positionList.list))
 	for i, _ := range nextRoots {
-		rootPos := len(nextRootPositions) - (i + 1)
-		nt, ntsib, _, err := p.grabPos(nextRootPositions[rootPos])
+		rootPos := len(positionList.list) - (i + 1)
+		nt, ntsib, _, err := p.grabPos(positionList.list[rootPos])
 		if err != nil {
 			return err
 		}
 		if nt == nil {
-			return fmt.Errorf("want root %d at %d but nil", i, nextRootPositions[i])
+			return fmt.Errorf("want root %d at %d but nil", i, positionList.list[i])
 		}
 		if ntsib == nil {
 			// when turning a node into a root, it's "nieces" are really children,

--- a/accumulator/pollard.go
+++ b/accumulator/pollard.go
@@ -269,12 +269,12 @@ func (p *Pollard) rem2(dels []uint64) error {
 		// fmt.Printf("done with row %d %s\n", h, p.toString())
 	}
 
-	// fmt.Printf("preroot %s", p.toString())
 	// set new roots
-	nextRootPositions, _ := getRootsReverse(nextNumLeaves, ph)
+	nextRootPositions, _ := getRootsForwards(nextNumLeaves, ph)
 	nextRoots := make([]*polNode, len(nextRootPositions))
 	for i, _ := range nextRoots {
-		nt, ntsib, _, err := p.grabPos(nextRootPositions[i])
+		rootPos := len(nextRootPositions) - (i + 1)
+		nt, ntsib, _, err := p.grabPos(nextRootPositions[rootPos])
 		if err != nil {
 			return err
 		}
@@ -312,13 +312,7 @@ func (p *Pollard) hnFromPos(pos uint64) (*hashableNode, error) {
 // swapNodes swaps the nodes at positions a and b.
 // returns a hashable node with b, bsib, and bpar
 func (p *Pollard) swapNodes(s arrow, row uint8) (*hashableNode, error) {
-
-	// if !inForest(s.from, p.numLeaves, p.rows()) ||
-	// !inForest(s.to, p.numLeaves, p.rows()) {
-	// return nil, fmt.Errorf("swapNodes %d %d out of bounds nl %d",
-	// s.from, s.to, p.numLeaves)
-	// }
-
+	// First operate on the position map for the fullPollard types
 	if p.positionMap != nil {
 		a := childMany(s.from, row, p.rows())
 		b := childMany(s.to, row, p.rows())
@@ -352,8 +346,6 @@ func (p *Pollard) swapNodes(s arrow, row uint8) (*hashableNode, error) {
 		return nil, fmt.Errorf("swapNodes %d %d node not found", s.from, s.to)
 	}
 
-	// fmt.Printf("swapNodes swapping a %d %x with b %d %x\n",
-	// r.from, a.data[:4], r.to, b.data[:4])
 	bhn.position = parent(s.to, p.rows())
 	// do the actual swap here
 	err = polSwap(a, asib, b, bsib)

--- a/accumulator/pollard_test.go
+++ b/accumulator/pollard_test.go
@@ -61,17 +61,9 @@ func TestPollardSimpleIngest(t *testing.T) {
 }
 
 func pollardRandomRemember(blocks int32) error {
-
-	// ffile, err := os.Create("/dev/shm/forfile")
-	// if err != nil {
-	// return err
-	// }
-
 	f := NewForest(nil, false, "", 0)
 
 	var p Pollard
-
-	// p.Minleaves = 0
 
 	sn := NewSimChain(0x07)
 	sn.lookahead = 400
@@ -91,7 +83,7 @@ func pollardRandomRemember(blocks int32) error {
 		if err != nil {
 			return err
 		}
-		fmt.Printf("del %v\n", bp.Targets)
+		fmt.Printf("deletions: %v\n", bp.Targets)
 
 		// apply adds and deletes to the bridge node (could do this whenever)
 		_, err = f.Modify(adds, bp.Targets)
@@ -134,7 +126,7 @@ func pollardRandomRemember(blocks int32) error {
 		}
 
 		fullTops := f.getRoots()
-		polTops := p.rootHashesReverse()
+		polTops := p.rootHashesForward()
 
 		// check that tops match
 		if len(fullTops) != len(polTops) {
@@ -142,11 +134,13 @@ func pollardRandomRemember(blocks int32) error {
 				sn.blockHeight, len(fullTops), len(polTops))
 		}
 		fmt.Printf("top matching: ")
-		for i, ft := range fullTops {
-			fmt.Printf("f %04x p %04x ", ft[:4], polTops[i][:4])
-			if ft != polTops[i] {
+		for i, pt := range polTops {
+			fmt.Printf("p %04x f %04x ", pt[:4],
+				fullTops[i][:4])
+			if pt != fullTops[i] {
 				return fmt.Errorf("block %d top %d mismatch, full %x pol %x",
-					sn.blockHeight, i, ft[:4], polTops[i][:4])
+					sn.blockHeight, i, pt[:4],
+					fullTops[i][:4])
 			}
 		}
 		fmt.Printf("\n")

--- a/accumulator/pollardfull.go
+++ b/accumulator/pollardfull.go
@@ -85,8 +85,10 @@ func (p *Pollard) ProveBatch(hs []Hash) (BatchProof, error) {
 	// guess is no, but that's untested.
 	sortUint64s(bp.Targets)
 
-	proofPositions, _ := ProofPositions(bp.Targets, p.numLeaves, p.rows())
-	targetsAndProof := mergeSortedSlices(proofPositions, bp.Targets)
+	positionList := NewPositionList()
+	defer positionList.Free()
+	ProofPositions(bp.Targets, p.numLeaves, p.rows(), &positionList.list)
+	targetsAndProof := mergeSortedSlices(positionList.list, bp.Targets)
 	bp.Proof = make([]Hash, len(targetsAndProof))
 	for i, proofPos := range targetsAndProof {
 		bp.Proof[i] = p.read(proofPos)

--- a/accumulator/pollardfull_test.go
+++ b/accumulator/pollardfull_test.go
@@ -79,8 +79,8 @@ func pollardFullRandomRemember(blocks int32) error {
 
 		fmt.Printf("fulpol postadd %s", fp.ToString())
 
-		fullTops := fp.rootHashesReverse()
-		polTops := p.rootHashesReverse()
+		fullTops := fp.rootHashesForward()
+		polTops := p.rootHashesForward()
 
 		// check that tops match
 		if len(fullTops) != len(polTops) {

--- a/accumulator/pollardutil.go
+++ b/accumulator/pollardutil.go
@@ -82,13 +82,11 @@ func polSwap(a, asib, b, bsib *polNode) error {
 }
 func (p *Pollard) rows() uint8 { return treeRows(p.numLeaves) }
 
-// rootHashesReverse is ugly and returns the root hashes in reverse order
-// ... which is the order full forest is using until I can refactor that code
-// to make it big to small order
-func (p *Pollard) rootHashesReverse() []Hash {
+// rootHashesForward grabs the rootHashes from left to right
+func (p *Pollard) rootHashesForward() []Hash {
 	rHashes := make([]Hash, len(p.roots))
 	for i, n := range p.roots {
-		rHashes[len(rHashes)-(1+i)] = n.data
+		rHashes[i] = n.data
 	}
 	return rHashes
 }

--- a/accumulator/utils.go
+++ b/accumulator/utils.go
@@ -318,23 +318,21 @@ func rootPosition(leaves uint64, h, forestRows uint8) uint64 {
 	return shifted & mask
 }
 
-// getroots gives you the positions of the tree roots, given a number of leaves.
-// LOWEST first (right to left) (blarg change this)
-func getRootsReverse(leaves uint64, forestRows uint8) (roots []uint64, rows []uint8) {
+// getRootsForwards gives you the positions of the tree roots, given a number of leaves.
+func getRootsForwards(leaves uint64, forestRows uint8) (roots []uint64, rows []uint8) {
 	position := uint64(0)
 
-	// go left to right.  But append in reverse so that the roots are low to high
-	// run though all bit positions.  if there's a 1, build a tree atop
-	// the current position, and move to the right.
 	for row := forestRows; position < leaves; row-- {
 		if (1<<row)&leaves != 0 {
 			// build a tree here
 			root := parentMany(position, row, forestRows)
-			roots = append([]uint64{root}, roots...)
-			rows = append([]uint8{row}, rows...)
+
+			roots = append(roots, root)
+			rows = append(rows, row)
 			position += 1 << row
 		}
 	}
+
 	return
 }
 


### PR DESCRIPTION
Changes made:

## getRootsForwards

getRootsReverse forces unnecessary allocations as the roots are
appended to a new list. This helps reduce the amount of memory
allocations, resulting in less time taken up by the gc.

Also, grabbing roots forwards is a lot cleaner than the reverse method.

## positionList

Positionlist (aka slice of uint64) is used numerous times in the accumulator code. Having a freelist for this list reduces gc pressure.

## computedPositions as int64 instead of a slice

All the functions that use computedPositions only take the length of the computedPositions slice. Changing this to just a int64 reduces gc pressure and speeds up the code.