### PR TITLE
bridgenode: Add http server for profiling and fix memprof

### DIFF
--- a/bridgenode/config.go
+++ b/bridgenode/config.go
@@ -54,6 +54,8 @@ var (
 		`Enable pprof cpu profiling. Usage: 'cpuprof='path/to/file'`)
 	memProfCmd = argCmd.String("memprof", "",
 		`Enable pprof heap profiling. Usage: 'memprof='path/to/file'`)
+	profServerCmd = argCmd.String("profserver", "",
+		`Enable pprof server. Usage: 'profserver='port'`)
 )
 
 // utreexo home directory
@@ -187,6 +189,9 @@ type Config struct {
 
 	// enable memory profiling
 	MemProf string
+
+	// enable profiling http server
+	ProfServer string
 }
 
 // Parse parses the command line arguments and inits the server Config
@@ -242,6 +247,7 @@ func Parse(args []string) (*Config, error) {
 	cfg.CpuProf = *cpuProfCmd
 	cfg.MemProf = *memProfCmd
 	cfg.TraceProf = *traceCmd
+	cfg.ProfServer = *profServerCmd
 
 	switch *forestTypeCmd {
 	case "disk":

--- a/cmd/utreexoserver/bridgeserver.go
+++ b/cmd/utreexoserver/bridgeserver.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"fmt"
+	_ "net/http/pprof"
 	"os"
 	"os/signal"
+	"runtime"
 	"runtime/debug"
 	"runtime/pprof"
 	"runtime/trace"
@@ -48,6 +50,16 @@ func handleIntSig(sig chan bool, cfg *bridge.Config) {
 
 		if cfg.TraceProf != "" {
 			trace.Stop()
+		}
+
+		if cfg.MemProf != "" {
+			f, err := os.Create(cfg.MemProf)
+			if err != nil {
+				fmt.Println(err)
+			}
+			runtime.GC()
+			pprof.WriteHeapProfile(f)
+
 		}
 		sig <- true
 	}()


### PR DESCRIPTION
Adds a flag to enable live pprof http server. Also fixes the memprof
so that the memory profile taken is done at exit not at the start