### PR TITLE
accumulator/forestdata: Improvements to cowforest

### DIFF
--- a/accumulator/forest_test.go
+++ b/accumulator/forest_test.go
@@ -26,13 +26,11 @@ func TestDeleteReverseOrder(t *testing.T) {
 }
 
 func TestForestAddDel(t *testing.T) {
-
 	numAdds := uint32(10)
 
 	f := NewForest(nil, false, "", 0)
 
 	sc := NewSimChain(0x07)
-	sc.lookahead = 400
 
 	for b := 0; b < 1000; b++ {
 
@@ -55,7 +53,7 @@ func TestCowForestAddDelComp(t *testing.T) {
 	numAdds := uint32(1000)
 
 	tmpDir := os.TempDir()
-	cowF := NewForest(nil, false, tmpDir, 500)
+	cowF := NewForest(nil, false, tmpDir, 2500)
 	memF := NewForest(nil, false, "", 0)
 
 	sc := NewSimChain(0x07)

--- a/bridgenode/config.go
+++ b/bridgenode/config.go
@@ -40,8 +40,8 @@ var (
 		`Set a custom bridgenode datadir. Usage: "-bridgedir='path/to/directory"`)
 	forestTypeCmd = argCmd.String("forest", "disk",
 		`Set a forest type to use (cow, ram, disk, cache). Usage: "-forest=cow"`)
-	cowMaxCache = argCmd.Int("cowmaxcache", 500,
-		`how many treetables to cache with copy-on-write forest`)
+	cowMaxCache = argCmd.Int("cowmaxcache", 4000,
+		`how much memory to use in MB for the copy-on-write forest`)
 	quitAtCmd = argCmd.Int("quitat", -1,
 		`quit generating proofs after the given block height. (meant for testing)`)
 	serve = argCmd.Bool("serve", false,


### PR DESCRIPTION
Things done:

1. Add caching strategy to cowForest.It has a slightly better caching now. cowForest treeBlocks (subtrees) now have a height of 1 (3 leaves). This makes the cowForest **not** backwards compatible with a previously saved cowForest.

2. Add stats for treeTable hits/misses. (misses are very low).

3. Add a test for writing the cowforest (tests flushes as well).

4. Flag for cowmaxcache now in MB instead of treeTable max count.



