### PR TITLE
accumulator/pollard: Fix slice allocation

### DIFF
--- a/accumulator/pollard.go
+++ b/accumulator/pollard.go
@@ -480,7 +480,7 @@ func (p *Pollard) toFull() (*Forest, error) {
 func (p *Pollard) GetRoots() (h []Hash) {
 	// pre-allocate. Shouldn't matter too much because this is only to export the
 	// utreexo state
-	h = make([]Hash, len(p.roots))
+	h = make([]Hash, 0, len(p.roots))
 
 	for _, pn := range p.roots {
 		h = append(h, pn.data)


### PR DESCRIPTION
There was a bug in where the slice allocation was appending empty
(filled with 0s) slices. Fixes this.