### PR TITLE
btcacc && accumulator: Update comments and remove some costly checks

### DIFF
--- a/accumulator/types.go
+++ b/accumulator/types.go
@@ -7,7 +7,7 @@ import (
 	"math/rand"
 )
 
-// Hash :
+// Hash is the 32 bytes of a sha256 hash
 type Hash [32]byte
 
 // Prefix for printfs
@@ -15,16 +15,16 @@ func (h Hash) Prefix() []byte {
 	return h[:4]
 }
 
-// Mini :
+// Mini takes the first 12 slices of a hash and outputs a MiniHash
 func (h Hash) Mini() (m MiniHash) {
 	copy(m[:], h[:12])
 	return
 }
 
-// MiniHash :
+// MiniHash is the first 12 bytes of a sha256 hash
 type MiniHash [12]byte
 
-// HashFromString :
+// HashFromString takes a string and hashes with sha256
 func HashFromString(s string) Hash {
 	return sha256.Sum256([]byte(s))
 }
@@ -35,7 +35,8 @@ type arrow struct {
 	collapse bool
 }
 
-// Node :
+// node is an element in the utreexo tree and is represented by a position
+// and a hash
 type node struct {
 	Pos uint64
 	Val Hash
@@ -53,9 +54,9 @@ type simLeaf struct {
 	duration int32
 }
 
-// Parent gets you the merkle parent.  So far no committing to height.
-// if the left child is zero it should crash...
+// parentHash gets you the merkle parent of two children hashes.
 func parentHash(l, r Hash) Hash {
+	// TODO So far no committing to height.
 	var empty Hash
 	if l == empty || r == empty {
 		panic("got an empty leaf here. ")
@@ -73,7 +74,7 @@ type SimChain struct {
 	lookahead    int32
 }
 
-// NewSimChain :
+// NewSimChain initializes and returns a Simchain
 func NewSimChain(duration uint32) *SimChain {
 	var s SimChain
 	s.blockHeight = -1
@@ -119,7 +120,8 @@ func (s *SimChain) ttlString() string {
 	return x
 }
 
-// NextBlock :
+// NextBlock outputs a new simulation block given the additions for the block
+// to be outputed
 func (s *SimChain) NextBlock(numAdds uint32) ([]Leaf, []int32, []Hash) {
 	s.blockHeight++
 	fmt.Printf("blockHeight %d\n", s.blockHeight)

--- a/btcacc/leaf_test.go
+++ b/btcacc/leaf_test.go
@@ -1,0 +1,38 @@
+package btcacc
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+)
+
+func TestLeafDataSerialize(t *testing.T) {
+	ld := LeafData{
+		TxHash:   Hash{1, 2, 3, 4},
+		Index:    0,
+		Height:   2,
+		Coinbase: false,
+		Amt:      3000,
+		PkScript: []byte{1, 2, 3, 4, 5, 6},
+	}
+
+	// Before
+	writer := &bytes.Buffer{}
+	ld.Serialize(writer)
+	beforeBytes := writer.Bytes()
+
+	// After
+	checkLeaf := LeafData{}
+	checkLeaf.Deserialize(writer)
+
+	afterWriter := &bytes.Buffer{}
+	checkLeaf.Serialize(afterWriter)
+	afterBytes := afterWriter.Bytes()
+
+	if !bytes.Equal(beforeBytes, afterBytes) {
+		err := fmt.Errorf("Serialize/Deserialize LeafData fail\n"+
+			"beforeBytes len: %v\n, afterBytes len:%v\n",
+			len(beforeBytes), len(afterBytes))
+		t.Fatal(err)
+	}
+}

--- a/btcacc/udata.go
+++ b/btcacc/udata.go
@@ -105,23 +105,16 @@ func (ud *UData) Serialize(w io.Writer) (err error) {
 	return
 }
 
-//
+// SerializeSize outputs the size of the udata when it is serialized
 func (ud *UData) SerializeSize() int {
 	var ldsize int
 	var b bytes.Buffer
 
-	// TODO this is slow, can remove double checking once it works reliably
+	// Grab the size of all the stxos
 	for _, l := range ud.Stxos {
 		ldsize += l.SerializeSize()
-		b.Reset()
-		l.Serialize(&b)
-		if b.Len() != l.SerializeSize() {
-			fmt.Printf(" b.Len() %d, l.SerializeSize() %d\n",
-				b.Len(), l.SerializeSize())
-		}
 	}
 
-	b.Reset()
 	ud.AccProof.Serialize(&b)
 	if b.Len() != ud.AccProof.SerializeSize() {
 		fmt.Printf(" b.Len() %d, AccProof.SerializeSize() %d\n",


### PR DESCRIPTION
Adds test for leafData serialization. Also removes the additional check
that's done for udata during SerializeSize() as it is very costly.