### PR TITLE
accumulator/batchproof: Remove target hashes from BatchProof

### DIFF
--- a/accumulator/batchproof.go
+++ b/accumulator/batchproof.go
@@ -20,8 +20,9 @@ type BatchProof struct {
 	Targets []uint64
 
 	// All the nodes in the tree that are needed to hash up to the root of
-	// the tree. If Targets are [00, 01], then Proof would be [00, 01, 05].
-	// TODO: Remove targets from the proof as it is redundant.
+	// the tree. Here, the root is 06. If Targets are [00, 01], then Proof
+	// would be [05] as you need 04 and 05 to hash to 06. 04 can be calculated
+	// by hashing 00 and 01.
 	//
 	// 06
 	// |-------\
@@ -237,40 +238,70 @@ type miniTree struct {
 	rightChild node
 }
 
-// TODO OH WAIT -- this is not how to to it!  Don't hash all the way up to the
-// roots to verify -- just hash up to any populated node!  Saves a ton of CPU!
+// targPos is just targets with their hashes. Used for sorting
+type targPos struct {
+	pos uint64
+	val Hash
+}
 
 // verifyBatchProof verifies a batchproof by checking against the set of known
 // correct roots.
 // Takes a BatchProof, the accumulator roots, and the number of leaves in the forest.
 // Returns wether or not the proof verified correctly, the partial proof tree,
 // and the subset of roots that was computed.
-func verifyBatchProof(bp BatchProof, roots []Hash, numLeaves uint64,
+//
+// NOTE: targetHashes MUST be in the same order they were proven in. (aka they
+// have to be in the same order as hashes given to ProveBatch(). In Bitcoin's
+// case, this would be the order in which they appear in a block.
+//
+// TODO OH WAIT -- this is not how to to it!  Don't hash all the way up to the
+// roots to verify -- just hash up to any populated node!  Saves a ton of CPU!
+func verifyBatchProof(targetHashes []Hash, bp BatchProof, roots []Hash, numLeaves uint64,
 	// cached should be a function that fetches nodes from the pollard and
 	// indicates whether they exist or not, this is only useful for the pollard
 	// and nil should be passed for the forest.
 	cached func(pos uint64) (bool, Hash)) (bool, [][]miniTree, []node) {
+
+	// If there is nothing to prove, return true
 	if len(bp.Targets) == 0 {
 		return true, nil, nil
 	}
+	// There should be a hash for each of the targets being proven
+	if len(bp.Targets) != len(targetHashes) {
+		return false, nil, nil
+	}
 
-	// copy targets to leave them in original order
+	tPos := make([]targPos, len(bp.Targets))
+
+	for i, hash := range targetHashes {
+		tPos[i].val = hash
+		tPos[i].pos = bp.Targets[i]
+	}
+
+	sortTargPos(tPos)
+
+	sortedDelHashes := make([]Hash, len(bp.Targets))
 	targets := make([]uint64, len(bp.Targets))
-	copy(targets, bp.Targets)
-	sortUint64s(targets)
+	for i, t := range tPos {
+		sortedDelHashes[i] = t.val
+		targets[i] = t.pos
+	}
+
+	targetHashes = sortedDelHashes
 
 	if cached == nil {
 		cached = func(_ uint64) (bool, Hash) { return false, empty }
 	}
 
 	rows := treeRows(numLeaves)
-	positionList := NewPositionList()
-	defer positionList.Free()
+	proofPositions := NewPositionList()
+	defer proofPositions.Free()
 
-	ProofPositions(targets, numLeaves, rows, &positionList.list)
+	// Grab all the positions needed to prove the targets
+	ProofPositions(targets, numLeaves, rows, &proofPositions.list)
 
 	// The proof should have as many hashes as there are proof positions.
-	if len(positionList.list)+len(bp.Targets) != len(bp.Proof) {
+	if len(proofPositions.list) != len(bp.Proof) {
 		return false, nil, nil
 	}
 
@@ -287,9 +318,7 @@ func verifyBatchProof(bp BatchProof, roots []Hash, numLeaves uint64,
 	trees := make([][]miniTree, len(roots))
 
 	// initialise the targetNodes for row 0.
-	// TODO: this would be more straight forward if bp.Proofs wouldn't
-	// contain the targets
-	proofHashes := make([]Hash, 0, len(positionList.list))
+	proofHashes := make([]Hash, 0, len(proofPositions.list))
 	var targetsMatched uint64
 	for len(targets) > 0 {
 		// check if the target is the row 0 root.
@@ -299,21 +328,20 @@ func verifyBatchProof(bp BatchProof, roots []Hash, numLeaves uint64,
 			// target is the row 0 root, append it to the root candidates.
 			rootCandidates = append(rootCandidates,
 				node{Val: roots[len(roots)-1], Pos: targets[0]})
-			bp.Proof = bp.Proof[1:]
 			break
 		}
 
 		// `targets` might contain a target and its sibling or just the target, if
 		// only the target is present the sibling will be in `proofPositions`.
-		if uint64(len(positionList.list)) > targetsMatched &&
-			targets[0]^1 == positionList.list[targetsMatched] {
-			// the sibling of the target is included in the proof positions.
-			lr := targets[0] & 1
-			targetNodes = append(targetNodes, node{Pos: targets[0], Val: bp.Proof[lr]})
-			proofHashes = append(proofHashes, bp.Proof[lr^1])
+		if uint64(len(proofPositions.list)) > targetsMatched &&
+			targets[0]^1 == proofPositions.list[targetsMatched] {
+			targetNodes = append(targetNodes, node{Pos: targets[0], Val: targetHashes[0]})
+			proofHashes = append(proofHashes, bp.Proof[0])
+
 			targetsMatched++
-			bp.Proof = bp.Proof[2:]
+			bp.Proof = bp.Proof[1:]
 			targets = targets[1:]
+			targetHashes = targetHashes[1:]
 			continue
 		}
 
@@ -321,14 +349,15 @@ func verifyBatchProof(bp BatchProof, roots []Hash, numLeaves uint64,
 		// it has to be included in targets. if there are less than 2 proof
 		// hashes or less than 2 targets left the proof is invalid because
 		// there is a target without matching proof.
-		if len(bp.Proof) < 2 || len(targets) < 2 {
+		if len(targetHashes) < 2 || len(targets) < 2 {
 			return false, nil, nil
 		}
 
 		targetNodes = append(targetNodes,
-			node{Pos: targets[0], Val: bp.Proof[0]},
-			node{Pos: targets[1], Val: bp.Proof[1]})
-		bp.Proof = bp.Proof[2:]
+			node{Pos: targets[0], Val: targetHashes[0]},
+			node{Pos: targets[1], Val: targetHashes[1]})
+
+		targetHashes = targetHashes[2:]
 		targets = targets[2:]
 	}
 
@@ -340,10 +369,11 @@ func verifyBatchProof(bp BatchProof, roots []Hash, numLeaves uint64,
 	for len(targetNodes) > 0 {
 		var target, proof node
 		target = targetNodes[0]
-		if len(positionList.list) > 0 && target.Pos^1 == positionList.list[0] {
+
+		if len(proofPositions.list) > 0 && target.Pos^1 == proofPositions.list[0] {
 			// target has a sibling in the proof positions, fetch proof
-			proof = node{Pos: positionList.list[0], Val: bp.Proof[0]}
-			positionList.list = positionList.list[1:]
+			proof = node{Pos: proofPositions.list[0], Val: bp.Proof[0]}
+			proofPositions.list = proofPositions.list[1:]
 			bp.Proof = bp.Proof[1:]
 			targetNodes = targetNodes[1:]
 		} else {
@@ -464,7 +494,6 @@ func (bp *BatchProof) Reconstruct(
 	defer positionList.Free()
 
 	ProofPositions(targets, numleaves, forestRows, &positionList.list)
-	positionList.list = mergeSortedSlices(targets, positionList.list)
 
 	if len(positionList.list) != len(bp.Proof) {
 		return nil, fmt.Errorf("Reconstruct wants %d hashes, has %d",

--- a/accumulator/batchproof_test.go
+++ b/accumulator/batchproof_test.go
@@ -30,16 +30,17 @@ func TestIncompleteBatchProof(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	leavesToProve := []Hash{adds[lastIdx].Hash}
+
 	// create blockProof based on the last add in the slice
-	blockProof, err := f.ProveBatch(
-		[]Hash{adds[lastIdx].Hash})
+	blockProof, err := f.ProveBatch(leavesToProve)
 
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	blockProof.Proof = blockProof.Proof[:len(blockProof.Proof)-1]
-	shouldBeFalse := f.VerifyBatchProof(blockProof)
+	shouldBeFalse := f.VerifyBatchProof(leavesToProve, blockProof)
 	if shouldBeFalse != false {
 		t.Fail()
 		t.Logf("Incomplete proof passes verification")
@@ -72,16 +73,17 @@ func TestVerifyBatchProof(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	leavesToProve := []Hash{adds[lastIdx].Hash}
+
 	// create blockProof based on the last add in the slice
-	blockProof, err := f.ProveBatch(
-		[]Hash{adds[lastIdx].Hash})
+	blockProof, err := f.ProveBatch(leavesToProve)
 
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Confirm that verify block proof works
-	shouldBetrue := f.VerifyBatchProof(blockProof)
+	shouldBetrue := f.VerifyBatchProof(leavesToProve, blockProof)
 	if shouldBetrue != true {
 		t.Fail()
 		t.Logf("Block failed to verify")
@@ -96,7 +98,7 @@ func TestVerifyBatchProof(t *testing.T) {
 	}
 
 	// Attempt to verify block proof with deleted element
-	shouldBeFalse := f.VerifyBatchProof(blockProof)
+	shouldBeFalse := f.VerifyBatchProof(leavesToProve, blockProof)
 	if shouldBeFalse != false {
 		t.Fail()
 		t.Logf("Block verified with old proof. Double spending allowed.")
@@ -128,7 +130,7 @@ func TestProofShouldNotValidateAfterNodeDeleted(t *testing.T) {
 		t.Fatal(fmt.Errorf("ProveBlock of existing values: %v", err))
 	}
 
-	if !f.VerifyBatchProof(batchProof) {
+	if !f.VerifyBatchProof([]Hash{adds[proofIndex].Hash}, batchProof) {
 		t.Fatal(
 			fmt.Errorf(
 				"proof of %d didn't verify (before deletion)",
@@ -140,7 +142,7 @@ func TestProofShouldNotValidateAfterNodeDeleted(t *testing.T) {
 		t.Fatal(fmt.Errorf("Modify with deletions: %v", err))
 	}
 
-	if f.VerifyBatchProof(batchProof) {
+	if f.VerifyBatchProof([]Hash{adds[proofIndex].Hash}, batchProof) {
 		t.Fatal(
 			fmt.Errorf(
 				"proof of %d is still valid (after deletion)",

--- a/accumulator/forest_test.go
+++ b/accumulator/forest_test.go
@@ -325,13 +325,15 @@ func addDelFullBatchProof(nAdds, nDels int) error {
 		addHashes[i] = h.Hash
 	}
 
+	leavesToProve := addHashes[:nDels]
+
 	// get block proof
-	bp, err := f.ProveBatch(addHashes[:nDels])
+	bp, err := f.ProveBatch(leavesToProve)
 	if err != nil {
 		return err
 	}
 	// check block proof.  Note this doesn't delete anything, just proves inclusion
-	worked, _, _ := verifyBatchProof(bp, f.getRoots(), f.numLeaves, nil)
+	worked, _, _ := verifyBatchProof(leavesToProve, bp, f.getRoots(), f.numLeaves, nil)
 	//	worked := f.VerifyBatchProof(bp)
 
 	if !worked {
@@ -440,7 +442,7 @@ func TestSmallRandomForests(t *testing.T) {
 				t.Fatalf("proveblock failed proving existing leaf: %v", err)
 			}
 
-			if !(f.VerifyBatchProof(blockProof)) {
+			if !(f.VerifyBatchProof([]Hash{chosenUndeletedLeaf.Hash}, blockProof)) {
 				t.Fatal("verifyblockproof failed verifying proof for existing leaf")
 			}
 		}

--- a/accumulator/forestproofs.go
+++ b/accumulator/forestproofs.go
@@ -132,8 +132,9 @@ func (f *Forest) VerifyMany(ps []Proof) bool {
 // ProveBatch gets proofs (in the form of a node slice) for a bunch of leaves
 // The ordering of Targets is the same as the ordering of hashes given as
 // argument.
-// NOTE However targets will need to be sorted before using the proof!
-// TODO the elements to be proven should not be included in the proof.
+//
+// NOTE: The order in which the hashes are given matter when verifying
+// (aka permutation matters).
 func (f *Forest) ProveBatch(hs []Hash) (BatchProof, error) {
 	starttime := time.Now()
 	var bp BatchProof
@@ -151,7 +152,6 @@ func (f *Forest) ProveBatch(hs []Hash) (BatchProof, error) {
 	bp.Targets = make([]uint64, len(hs))
 
 	for i, wanted := range hs {
-
 		pos, ok := f.positionMap[wanted.Mini()]
 		if !ok {
 			fmt.Print(f.ToString())
@@ -177,14 +177,14 @@ func (f *Forest) ProveBatch(hs []Hash) (BatchProof, error) {
 	copy(sortedTargets, bp.Targets)
 	sortUint64s(sortedTargets)
 
-	positionList := NewPositionList()
-	defer positionList.Free()
+	proofPositions := NewPositionList()
+	defer proofPositions.Free()
 
-	ProofPositions(sortedTargets, f.numLeaves, f.rows, &positionList.list)
-	targetsAndProof := mergeSortedSlices(positionList.list, sortedTargets)
+	// Get the positions of all the hashes that are needed to prove the targets
+	ProofPositions(sortedTargets, f.numLeaves, f.rows, &proofPositions.list)
 
-	bp.Proof = make([]Hash, len(targetsAndProof))
-	for i, proofPos := range targetsAndProof {
+	bp.Proof = make([]Hash, len(proofPositions.list))
+	for i, proofPos := range proofPositions.list {
 		bp.Proof[i] = f.data.read(proofPos)
 	}
 
@@ -197,8 +197,8 @@ func (f *Forest) ProveBatch(hs []Hash) (BatchProof, error) {
 	return bp, nil
 }
 
-// VerifyBatchProof :
-func (f *Forest) VerifyBatchProof(bp BatchProof) bool {
-	ok, _, _ := verifyBatchProof(bp, f.getRoots(), f.numLeaves, nil)
+// VerifyBatchProof is just a wrapper around verifyBatchProof
+func (f *Forest) VerifyBatchProof(toProve []Hash, bp BatchProof) bool {
+	ok, _, _ := verifyBatchProof(toProve, bp, f.getRoots(), f.numLeaves, nil)
 	return ok
 }

--- a/accumulator/pollard_test.go
+++ b/accumulator/pollard_test.go
@@ -53,8 +53,11 @@ func TestPollardSimpleIngest(t *testing.T) {
 	var p Pollard
 	p.Modify(adds, nil)
 	// Modify the proof so that the verification should fail.
-	bp.Proof[0][0] = 0xFF
-	err := p.IngestBatchProof(bp)
+	if len(bp.Proof) <= 0 {
+		bp.Proof = make([]Hash, 1)
+		bp.Proof[0][0] = 0xFF
+	}
+	err := p.IngestBatchProof(hashes, bp)
 	if err == nil {
 		t.Fatal("BatchProof valid after modification. Accumulator validation failing")
 	}
@@ -78,12 +81,12 @@ func pollardRandomRemember(blocks int32) error {
 		if err != nil {
 			return err
 		}
+
 		// verify proofs on rad node
-		err = p.IngestBatchProof(bp)
+		err = p.IngestBatchProof(delHashes, bp)
 		if err != nil {
 			return err
 		}
-		fmt.Printf("deletions: %v\n", bp.Targets)
 
 		// apply adds and deletes to the bridge node (could do this whenever)
 		_, err = f.Modify(adds, bp.Targets)
@@ -230,12 +233,13 @@ func TestCache(t *testing.T) {
 		if err != nil {
 			t.Fatal("ProveBatch failed", err)
 		}
+
 		_, err = f.Modify(adds, proof.Targets)
 		if err != nil {
 			t.Fatal("Modify failed", err)
 		}
 
-		err = p.IngestBatchProof(proof)
+		err = p.IngestBatchProof(delHashes, proof)
 		if err != nil {
 			t.Fatal("IngestBatchProof failed", err)
 		}

--- a/accumulator/pollardfull_test.go
+++ b/accumulator/pollardfull_test.go
@@ -46,7 +46,7 @@ func pollardFullRandomRemember(blocks int32) error {
 		}
 
 		// verify proofs on rad node
-		err = p.IngestBatchProof(bp)
+		err = p.IngestBatchProof(delHashes, bp)
 		if err != nil {
 			return err
 		}

--- a/accumulator/pollardproof.go
+++ b/accumulator/pollardproof.go
@@ -6,10 +6,10 @@ import (
 
 // IngestBatchProof populates the Pollard with all needed data to delete the
 // targets in the block proof
-func (p *Pollard) IngestBatchProof(bp BatchProof) error {
+func (p *Pollard) IngestBatchProof(toProve []Hash, bp BatchProof) error {
 	// verify the batch proof.
 	rootHashes := p.rootHashesForward()
-	ok, trees, roots := verifyBatchProof(bp, rootHashes, p.numLeaves,
+	ok, trees, roots := verifyBatchProof(toProve, bp, rootHashes, p.numLeaves,
 		// pass a closure that checks the pollard for cached nodes.
 		// returns true and the hash value of the node if it exists.
 		// returns false if the node does not exist or the hash value is empty.

--- a/accumulator/utils.go
+++ b/accumulator/utils.go
@@ -446,6 +446,10 @@ func sortNodeSlice(s []node) {
 	sort.Slice(s, func(a, b int) bool { return s[a].Pos < s[b].Pos })
 }
 
+func sortTargPos(s []targPos) {
+	sort.Slice(s, func(a, b int) bool { return s[a].pos < s[b].pos })
+}
+
 // checkSortedNoDupes returns true for strictly increasing slices
 func checkSortedNoDupes(s []uint64) bool {
 	for i, _ := range s {

--- a/go.mod
+++ b/go.mod
@@ -12,5 +12,5 @@ require (
 	golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980 // indirect
 )
 
-replace github.com/btcsuite/btcd => github.com/mit-dci/utcd v0.21.0-beta.0.20210201215500-359f1ee1429a
+replace github.com/btcsuite/btcd => github.com/mit-dci/utcd v0.21.0-beta.0.20210622094436-95ee13404deb
 replace github.com/btcsuite/btcutil => github.com/mit-dci/utcutil v1.0.3-0.20210201144513-fb3ce8742498

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ github.com/kcalvinalvin/btcd v0.20.1-beta.0.20210202084407-63bae2d12e01/go.mod h
 github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23/go.mod h1:J+Gs4SYgM6CZQHDETBtE9HaSEkGmuNXF86RwHhHUvq4=
 github.com/mit-dci/utcd v0.21.0-beta.0.20210201215500-359f1ee1429a h1:RzhKLugFs87PMOHxrQUcvkqyuqerpd7bWaUKdxwKMLI=
 github.com/mit-dci/utcd v0.21.0-beta.0.20210201215500-359f1ee1429a/go.mod h1:t4zbDmIvP+nfkgR383HSMks64wA8cloaI7o3THoptXY=
+github.com/mit-dci/utcd v0.21.0-beta.0.20210622094436-95ee13404deb h1:Nbl8bHM+atyDLFj7/PtL/kEzS0Ivrli4XSmj9e+F9Zo=
+github.com/mit-dci/utcd v0.21.0-beta.0.20210622094436-95ee13404deb/go.mod h1:aD9kiI2TXv3Fri33fAgQhRmUBJ0WwkiUchFTWnLXNPs=
 github.com/mit-dci/utcutil v1.0.3-0.20210201144513-fb3ce8742498 h1:luTD6pTVYv5BMGuf+GkOCedIYZo9jMaA5USZULZCCvM=
 github.com/mit-dci/utcutil v1.0.3-0.20210201144513-fb3ce8742498/go.mod h1:ST9y+SCOD6G6J48CwoMwtmQ+ATLrDuwS7rfZWNrsEPg=
 github.com/mit-dci/utreexo v0.0.0-20210113220559-fe368b8feff3/go.mod h1:Fkwf5QjCAkJxTCWWARKviyBWIX4v2NRcFsd0f0eZZjs=


### PR DESCRIPTION
Before, the target hashes also used to be included in the BatchProof.
However, these are just the hash commitments of elements to prove and
the user has all the data needed to calculate the hashes.

Removing them achieves two things: smaller proofs, simpler verification.

Since the hashes no longer is being stored, the proofs get smaller by
however many deletions that are to happen. The verification logic is
simpler as it no longer has to have extra logic to separate out the
target hashes from the actual proofs.