### PR TITLE
accumulator&bridgenode: Reset maps to avoid out of memory errors

### DIFF
--- a/bridgenode/config.go
+++ b/bridgenode/config.go
@@ -275,6 +275,11 @@ func Parse(args []string) (*Config, error) {
 	cfg.TraceProf = *traceCmd
 	cfg.ProfServer = *profServerCmd
 	cfg.memTTLdb = *memTTLdb
+
+	// If allInMemTTLdb flag was given, the ttldb has to be kept in ram
+	if *allInMemTTLdb {
+		cfg.memTTLdb = true
+	}
 	cfg.allInMemTTLdb = *allInMemTTLdb
 
 	switch *forestTypeCmd {

--- a/bridgenode/dbworker.go
+++ b/bridgenode/dbworker.go
@@ -314,6 +314,8 @@ func (mdb *MemTTLdb) Flush() error {
 		mdb.flushMax += (mdb.flushMax / 10)
 	}
 
+	// make new map and force gc to free the old map
+	mdb.cache = make(map[[36]byte]*cachedTTLIdx)
 	fmt.Println("Flushed ttldb cache", mdb.memUsage, len(mdb.cache))
 	return nil
 }


### PR DESCRIPTION
# First change

Go maps don't shrink when elements are deleted from the map, resulting in maps growing as time passes. This is documented in an issue here https://github.com/golang/go/issues/20135

This code snippet below shows that the allocated memory is the same even when all the elements are deleted from the map:

```
package main

import (
        "fmt"
        "runtime"
)

func bToMb(b uint64) uint64 {
        return b / 1024 / 1024
}

func PrintMemUsage() {
        var m runtime.MemStats
        runtime.ReadMemStats(&m)
        // For info on each, see: https://golang.org/pkg/runtime/#MemStats
        fmt.Printf("Alloc = %5d MiB", bToMb(m.Alloc))
        fmt.Printf("\tTotalAlloc = %5d MiB", bToMb(m.TotalAlloc))
        fmt.Printf("\tSys = %5d MiB", bToMb(m.Sys))
        fmt.Printf("\tNumGC = %2d\n", m.NumGC)
}

func main() {
        myMap := make(map[int]uint64)

        fmt.Println("ADD")

        for i := 0; i < 100000000; i++ {
                myMap[i] = uint64(i + 1)
                if i%10000000 == 0 {
                        PrintMemUsage()
                }
        }
        PrintMemUsage()

        fmt.Println()
        fmt.Println("DELETE")

        for i := 0; i < 100000000; i++ {
                delete(myMap, i)
                if i%10000000 == 0 {
                        PrintMemUsage()
                }
        }

        fmt.Println("myMap len:", len(myMap))
        PrintMemUsage()

        myMap = nil
        fmt.Println()
        fmt.Println("myMap set to nil")

        fmt.Println("Manual gc trigger")
        runtime.GC()

        PrintMemUsage()
}
```

In our current code, there are 2 maps that are used extensively for the entire duration of the code. One is `positionMap` in forest and the other is `memttldb`.

For forest, a new const `maxMapCount` is declared along with a new forest member variable `mapFreeCount`. For each deletion from the `positionMap`, `mapFreeCount` is incremented once. In `forest.cleanup()`, if `mapFreeCount` is greater than `maxMapCount`, a new map is created, letting the old map be garbage collected.

For `memttldb`, a new map is created during every flush.

# Second change

For `utreexoserver`, the flag `-memttldb` needed to be given in order for `-allttldbinmem` to work. The new code now automatically turns on flag `-memttldb` when flag `-allttldbinmem` is given.