### PR TITLE
cmd: Minor changes to utreexoserver and utreexoclient

### DIFF
--- a/bridgenode/config.go
+++ b/bridgenode/config.go
@@ -275,6 +275,11 @@ func Parse(args []string) (*Config, error) {
 	cfg.TraceProf = *traceCmd
 	cfg.ProfServer = *profServerCmd
 	cfg.memTTLdb = *memTTLdb
+
+	// If allInMemTTLdb flag was given, the ttldb has to be kept in ram
+	if *allInMemTTLdb {
+		cfg.memTTLdb = true
+	}
 	cfg.allInMemTTLdb = *allInMemTTLdb
 
 	switch *forestTypeCmd {

--- a/cmd/utreexoclient/csnclient.go
+++ b/cmd/utreexoclient/csnclient.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"runtime/pprof"

--- a/cmd/utreexoclient/csnclient.go
+++ b/cmd/utreexoclient/csnclient.go
@@ -5,8 +5,6 @@ import (
 	_ "net/http/pprof"
 	"os"
 	"os/signal"
-	"runtime/pprof"
-	"runtime/trace"
 	"syscall"
 
 	"github.com/mit-dci/utreexo/csn"
@@ -35,12 +33,6 @@ func handleIntSig(sig chan bool, cfg *csn.Config) {
 	signal.Notify(s, syscall.SIGINT, syscall.SIGQUIT, syscall.SIGTERM)
 	go func() {
 		<-s
-		if cfg.CpuProf != "" {
-			pprof.StopCPUProfile()
-		}
-		if cfg.TraceProf != "" {
-			trace.Stop()
-		}
 		sig <- true
 	}()
 }

--- a/csn/config.go
+++ b/csn/config.go
@@ -49,6 +49,8 @@ var (
 		`size of the look-ahead cache in blocks`)
 	quitafter = argCmd.Int("quitafter", -1,
 		`quit ibd after n blocks. (for testing)`)
+	profServerCmd = argCmd.String("profserver", "",
+		`Enable pprof server. Usage: 'profserver='port'`)
 )
 
 type Config struct {
@@ -77,6 +79,9 @@ type Config struct {
 
 	// enable memory profiling
 	MemProf string
+
+	// enable profiling http server
+	ProfServer string
 }
 
 func Parse(args []string) (*Config, error) {
@@ -113,6 +118,7 @@ func Parse(args []string) (*Config, error) {
 	cfg.CpuProf = *cpuProfCmd
 	cfg.MemProf = *memProfCmd
 	cfg.TraceProf = *traceCmd
+	cfg.ProfServer = *profServerCmd
 
 	return &cfg, nil
 }

--- a/csn/ibd.go
+++ b/csn/ibd.go
@@ -12,7 +12,7 @@ import (
 
 // run IBD from block proof data
 // we get the new utxo info from the same txos text file
-func (c *Csn) IBDThread(sig chan bool, quitafter int) {
+func (c *Csn) IBDThread(cfg Config, sig chan bool) {
 	// Channel to alert the main loop to break when receiving a quit signal from
 	// the OS
 	haltRequest := make(chan bool, 1)
@@ -21,7 +21,7 @@ func (c *Csn) IBDThread(sig chan bool, quitafter int) {
 	// Makes it wait for flushing to disk
 	haltAccept := make(chan bool, 1)
 
-	go stopRunIBD(sig, haltRequest, haltAccept)
+	go stopRunIBD(cfg, sig, haltRequest, haltAccept)
 
 	// caching parameter. Keeps txos that are spent before than this many blocks
 	lookahead := int32(1000)
@@ -72,7 +72,7 @@ func (c *Csn) IBDThread(sig chan bool, quitafter int) {
 
 		// quit after `quitafter` blocks if the -quitafter option is set
 		blockCount++
-		if quitafter > -1 && blockCount >= quitafter {
+		if cfg.quitafter > -1 && blockCount >= cfg.quitafter {
 			fmt.Println("quit after", quitafter, "blocks")
 			sig <- true
 			stop = true

--- a/csn/init.go
+++ b/csn/init.go
@@ -2,6 +2,8 @@ package csn
 
 import (
 	"fmt"
+	"net"
+	"net/http"
 	"os"
 	"runtime/pprof"
 	"runtime/trace"
@@ -38,6 +40,15 @@ func RunIBD(cfg *Config, sig chan bool) error {
 			return err
 		}
 		trace.Start(f)
+	}
+	if cfg.ProfServer != "" {
+		go func() {
+			listenAddr := net.JoinHostPort("", cfg.ProfServer)
+			profileRedirect := http.RedirectHandler("/debug/pprof",
+				http.StatusSeeOther)
+			http.Handle("/", profileRedirect)
+			fmt.Printf("%v", http.ListenAndServe(listenAddr, nil))
+		}()
 	}
 
 	// check on disk for pre-existing state and load it


### PR DESCRIPTION
Adds a profiling server flag for `utreexoclient`, which helps in getting snapshots of memory usage during when the binary is running. Also for `utreexoclient` now the memory profile snapshot is correctly taken during when the binary exits.

For `utreexoserver`, it now turns on `memttldb` flag when `allttldbinmem` flag is given. Before, you could give the `allttldbinmem` flag by itself and it would do nothing because the `memttldb` flag hasn't been given, which is not intuitive. 