### PR TITLE
accumulator/types: Less memory allocation for parentHash()

### DIFF
--- a/accumulator/types.go
+++ b/accumulator/types.go
@@ -63,11 +63,19 @@ type simLeaf struct {
 // parentHash gets you the merkle parent of two children hashes.
 func parentHash(l, r Hash) Hash {
 	// TODO So far no committing to height.
-	var empty Hash
 	if l == empty || r == empty {
 		panic("got an empty leaf here. ")
 	}
-	return sha512.Sum512_256(append(l[:], r[:]...))
+	h := sha512.New512_256()
+	h.Write(l[:])
+	h.Write(r[:])
+
+	// What h.Sum returns is always 32 bytes but since h.Sum is an interface that
+	// returns a slice of bytes, Go doesn't know this requires slice -> array
+	// copying.
+	rh := Hash{}
+	copy(rh[:], h.Sum(nil))
+	return rh
 }
 
 // simChain is for testing; it spits out "blocks" of adds and deletes


### PR DESCRIPTION
Previously, the left and right Hash slices were appended and then passed off to the hash function. This new hash method saves on the memory allocation that would have happened with the append by writing to the digest directly.

Below are the memory profile before and after the change in `parentHash()`. The test was done with `utreexoclient`  getting blocks locally from `utreexoserver` up to block #522315.

Before:
<img width="860" alt="Screen Shot 2021-07-05 at 7 31 36 PM" src="https://user-images.githubusercontent.com/37185887/124458856-75885a00-ddc8-11eb-82c2-82b6d5a937e1.png">

After:
<img width="909" alt="Screen Shot 2021-07-05 at 7 31 28 PM" src="https://user-images.githubusercontent.com/37185887/124458845-70c3a600-ddc8-11eb-8acf-5228bac57b2a.png">

We end up saving about a gig of memory allocations.