### PR TITLE
Pollard test for serialize and deserailize 

### DIFF
--- a/accumulator/pollard_test.go
+++ b/accumulator/pollard_test.go
@@ -1,8 +1,6 @@
 package accumulator
 
 import (
-	"bytes"
-	"errors"
 	"fmt"
 	"math/rand"
 	"testing"
@@ -34,16 +32,6 @@ func TestPollardFixed(t *testing.T) {
 		t.Fatal(err)
 	}
 }
-
-func TestPollardSerializeDeserialize(t *testing.T) {
-	rand.Seed(2)
-
-	err := PollardSerializeDeserialize()
-	if err != nil {
-		t.Fatal(err)
-	}
-}
-
 func TestPollardSimpleIngest(t *testing.T) {
 	f := NewForest(nil, false, "", 0)
 	adds := make([]Leaf, 15)
@@ -221,52 +209,6 @@ func fixedPollard(leaves int32) error {
 
 	if !p.equalToForest(f) {
 		return fmt.Errorf("p != f (leaves)")
-	}
-
-	return nil
-}
-
-func PollardSerializeDeserialize() error {
-	var p Pollard
-
-	// generate slice of leaf
-	leaves := make([]Leaf, 10)
-
-	for i := 0; i < len(leaves); i++ {
-		leaves[i].Hash[0] = uint8(i + 1)
-	}
-
-	// add leaves to pollard
-	p.add(leaves)
-
-	// performing serialization
-
-	old_byte, err := p.Serialize()
-
-	if err != nil {
-		return err
-	}
-
-	// perform Deserialize
-
-	err = p.Deserialize(old_byte)
-	if err != nil {
-		return err
-	}
-
-	// Serialize again and compare bytes
-
-	new_byte, err := p.Serialize()
-
-	if err != nil {
-		return err
-	}
-
-	res := bytes.Compare(old_byte, new_byte)
-
-	// If comaprison unequal return error
-	if res != 0 {
-		return errors.New("Bytes Unequal")
 	}
 
 	return nil

--- a/accumulator/pollard_test.go
+++ b/accumulator/pollard_test.go
@@ -1,6 +1,8 @@
 package accumulator
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
 	"math/rand"
 	"testing"
@@ -210,6 +212,51 @@ func fixedPollard(leaves int32) error {
 
 	if !p.equalToForest(f) {
 		return fmt.Errorf("p != f (leaves)")
+	}
+
+	return nil
+}
+
+func PollardSerializeDeserialize() error {
+	var p Pollard
+
+	// generate slice of leaf
+	leaves := make([]Leaf, 10)
+
+	for i := 0; i < len(leaves); i++ {
+		leaves[i].Hash[0] = uint8(i + 1)
+	}
+
+	// add leaves to pollard
+	p.add(leaves)
+
+	// performing serialization
+
+	old_byte, err := p.Serialize()
+
+	if err != nil {
+		return err
+	}
+
+	// perform Deserialize
+
+	err = p.Deserialize(old_byte)
+	if err != nil {
+		return err
+	}
+
+	// Serialize again and compare bytes
+
+	new_byte, err := p.Serialize()
+
+	if err != nil {
+		return err
+	}
+
+	res := bytes.Compare(old_byte, new_byte)
+
+	if res != 0 {
+		return errors.New("Bytes Unequal")
 	}
 
 	return nil

--- a/accumulator/pollard_test.go
+++ b/accumulator/pollard_test.go
@@ -35,6 +35,15 @@ func TestPollardFixed(t *testing.T) {
 	}
 }
 
+func TestPollardSerializeDeserialize(t *testing.T) {
+	rand.Seed(2)
+
+	err := PollardSerializeDeserialize()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestPollardSimpleIngest(t *testing.T) {
 	f := NewForest(nil, false, "", 0)
 	adds := make([]Leaf, 15)
@@ -255,6 +264,7 @@ func PollardSerializeDeserialize() error {
 
 	res := bytes.Compare(old_byte, new_byte)
 
+	// If comaprison unequal return error
 	if res != 0 {
 		return errors.New("Bytes Unequal")
 	}

--- a/accumulator/pollardutil_test.go
+++ b/accumulator/pollardutil_test.go
@@ -1,0 +1,45 @@
+package accumulator
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestPollardSerializeDeserialize(t *testing.T) {
+	var p, q Pollard
+	// generate slice of leaf
+	leaves := make([]Leaf, 10)
+	for i := 0; i < len(leaves); i++ {
+		leaves[i].Hash[0] = uint8(i + 1)
+	}
+	// add leaves to pollard
+	err := p.add(leaves)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// new pollard
+	err = q.add(leaves)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// performing serialization
+	old_byte, err := p.Serialize()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// perform Deserialize
+	err = q.Deserialize(old_byte)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Serialize again and compare bytes
+	new_byte, err := q.Serialize()
+	if err != nil {
+		t.Fatal(err)
+	}
+	res := bytes.Equal(old_byte, new_byte)
+	// If comaprison unequal return error
+	if !res {
+		t.Fatal("Bytes Unequal")
+	}
+}

--- a/accumulator/pollardutil_test.go
+++ b/accumulator/pollardutil_test.go
@@ -17,11 +17,6 @@ func TestPollardSerializeDeserialize(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// new pollard
-	err = q.add(leaves)
-	if err != nil {
-		t.Fatal(err)
-	}
 	// performing serialization
 	old_byte, err := p.Serialize()
 	if err != nil {


### PR DESCRIPTION
This works on the issue of  #295 

function PollardSerializeDeserialize() generates a pollard and serializes it and then deserailizes it  keeping account of the bytes count of the previous serialization.

The desearialized pollard is serailized again and the bytes obtained is compared with the previous serialization bytes.
If equal the test passes .

function TestPollardSerializeDeserialize() performs the testing