### PR TITLE
ref: NewForest function to use enums for forest types

### DIFF
--- a/accumulator/batchproof_test.go
+++ b/accumulator/batchproof_test.go
@@ -8,7 +8,7 @@ import (
 // TestIncompleteBatchProof tests that a incomplete (missing some hashes) batchproof does not pass verification.
 func TestIncompleteBatchProof(t *testing.T) {
 	// Create forest in memory
-	f := NewForest(nil, false, "", 0)
+	f := NewForest(RamForest, nil, "", 0)
 
 	// last index to be deleted. Same as blockDels
 	lastIdx := uint64(7)
@@ -51,7 +51,7 @@ func TestIncompleteBatchProof(t *testing.T) {
 // Utreexo forest.
 func TestVerifyBatchProof(t *testing.T) {
 	// Create forest in memory
-	f := NewForest(nil, false, "", 0)
+	f := NewForest(RamForest, nil, "", 0)
 
 	// last index to be deleted. Same as blockDels
 	lastIdx := uint64(7)
@@ -116,7 +116,7 @@ func TestProofShouldNotValidateAfterNodeDeleted(t *testing.T) {
 	adds[0].Hash = Hash{1} // will be deleted
 	adds[1].Hash = Hash{2} // will be proven
 
-	f := NewForest(nil, false, "", 0)
+	f := NewForest(RamForest, nil, "", 0)
 	_, err := f.Modify(adds, nil)
 	if err != nil {
 		t.Fatal(fmt.Errorf("Modify with initial adds: %v", err))

--- a/accumulator/forest.go
+++ b/accumulator/forest.go
@@ -93,59 +93,57 @@ type Forest struct {
 	timeInVerify time.Duration
 }
 
+// ForestType defines the 4 type of forests:
+// DiskForest, RamForest, CacheForest, CowForest
+type ForestType int
+
+const (
+	// DiskForest  - keeps the entire forest on disk as a flat file. Is the slowest
+	//               of them all. Pass an os.File as forestFile to create a DiskForest.
+	DiskForest ForestType = iota
+	// RamForest   - keeps the entire forest on ram as a slice. Is the fastest but
+	//               takes up a lot of ram. Is compatible with DiskForest (as in you
+	//               can restart as RamForest even if you created a DiskForest. Pass
+	//               nil, as the forestFile to create a RamForest.
+	RamForest
+	// CacheForest - keeps the entire forest on disk but caches recent nodes. It's
+	//               faster than disk. Is compatible with the above two forest types.
+	//               Pass cached = true to create a cacheForest.
+	CacheForest
+	// CowForest   - A copy-on-write (really a redirect on write) forest. It strikes
+	//               a balance between ram usage and speed. Not compatible with other
+	//               forest types though (meaning there isn't functionality implemented
+	//               to convert a CowForest to DiskForest and vise-versa). Pass a filepath
+	//               and cowMaxCache(how much MB to use in ram) to create a CowForest.
+	CowForest
+)
+
 // NewForest initializes a Forest and returns it. The given arguments determine
-// what type of forest it will be. There are currently four types:
-//
-// DiskForest  - keeps the entire forest on disk as a flat file. Is the slowest
-//               of them all. Pass an os.File as forestFile to create a DiskForest.
-//
-// RamForest   - keeps the entire forest on ram as a slice. Is the fastest but
-//               takes up a lot of ram. Is compatible with DiskForest (as in you
-//               can restart as RamForest even if you created a DiskForest. Pass
-//               nil, as the forestFile to create a RamForest.
-//
-// CacheForest - keeps the entire forest on disk but caches recent nodes. It's
-//               faster than disk. Is compatible with the above two forest types.
-//               Pass cached = true to create a cacheForest.
-//
-// CowForest   - A copy-on-write (really a redirect on write) forest. It strikes
-//               a balance between ram usage and speed. Not compatible with other
-//               forest types though (meaning there isn't functionality implemented
-//               to convert a CowForest to DiskForest and vise-versa). Pass a filepath
-//               and cowMaxCache(how much MB to use in ram) to create a CowForest.
-func NewForest(forestFile *os.File, cached bool,
-	cowPath string, cowMaxCache int) *Forest {
+// what type of forest it will be.
+func NewForest(forestType ForestType, forestFile *os.File, cowPath string, cowMaxCache int) *Forest {
 
 	f := new(Forest)
 	f.numLeaves = 0
 	f.rows = 0
 
-	if forestFile == nil {
-		if cowPath == "" {
-			// for in-ram
-			f.data = new(ramForestData)
-		} else {
-			// Init cowForest
-			d, err := initialize(cowPath, cowMaxCache)
-			if err != nil {
-				panic(err)
-			}
-			f.data = d
+	switch forestType {
+	case DiskForest:
+		d := new(diskForestData)
+		d.file = forestFile
+		f.data = d
+	case RamForest:
+		f.data = new(ramForestData)
+	case CacheForest:
+		d := new(cacheForestData)
+		d.file = forestFile
+		d.cache = newDiskForestCache(20)
+		f.data = d
+	case CowForest:
+		d, err := initialize(cowPath, cowMaxCache)
+		if err != nil {
+			panic(err)
 		}
-
-	} else {
-		// forest on disk or cached
-		if cached {
-			d := new(cacheForestData)
-			d.file = forestFile
-			d.cache = newDiskForestCache(20)
-			f.data = d
-		} else {
-			// for on-disk
-			d := new(diskForestData)
-			d.file = forestFile
-			f.data = d
-		}
+		f.data = d
 	}
 
 	f.data.resize((2 << f.rows) - 1)

--- a/accumulator/forest_test.go
+++ b/accumulator/forest_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestDeleteReverseOrder(t *testing.T) {
-	f := NewForest(nil, false, "", 0)
+	f := NewForest(RamForest, nil, "", 0)
 	leaf1 := Leaf{Hash: Hash{1}}
 	leaf2 := Leaf{Hash: Hash{2}}
 	_, err := f.Modify([]Leaf{leaf1, leaf2}, nil)
@@ -28,7 +28,7 @@ func TestDeleteReverseOrder(t *testing.T) {
 func TestForestAddDel(t *testing.T) {
 	numAdds := uint32(10)
 
-	f := NewForest(nil, false, "", 0)
+	f := NewForest(RamForest, nil, "", 0)
 
 	sc := newSimChain(0x07)
 
@@ -53,8 +53,8 @@ func TestCowForestAddDelComp(t *testing.T) {
 	numAdds := uint32(1000)
 
 	tmpDir := os.TempDir()
-	cowF := NewForest(nil, false, tmpDir, 2500)
-	memF := NewForest(nil, false, "", 0)
+	cowF := NewForest(CowForest, nil, tmpDir, 2500)
+	memF := NewForest(RamForest, nil, "", 0)
 
 	sc := newSimChain(0x07)
 	sc.lookahead = 400
@@ -173,7 +173,7 @@ func TestCowForestAddDel(t *testing.T) {
 	numAdds := uint32(10)
 
 	tmpDir := os.TempDir()
-	cowF := NewForest(nil, false, tmpDir, 500)
+	cowF := NewForest(CowForest, nil, tmpDir, 500)
 
 	sc := newSimChain(0x07)
 	sc.lookahead = 400
@@ -196,7 +196,7 @@ func TestCowForestAddDel(t *testing.T) {
 }
 
 func TestForestFixed(t *testing.T) {
-	f := NewForest(nil, false, "", 0)
+	f := NewForest(RamForest, nil, "", 0)
 	numadds := 5
 	numdels := 3
 	adds := make([]Leaf, numadds)
@@ -227,7 +227,7 @@ func TestForestFixed(t *testing.T) {
 
 // Add 2. delete 1.  Repeat.
 func Test2Fwd1Back(t *testing.T) {
-	f := NewForest(nil, false, "", 0)
+	f := NewForest(RamForest, nil, "", 0)
 	var absidx uint32
 	adds := make([]Leaf, 2)
 
@@ -306,7 +306,7 @@ func addDelFullBatchProof(nAdds, nDels int) error {
 		return fmt.Errorf("too many deletes")
 	}
 
-	f := NewForest(nil, false, "", 0)
+	f := NewForest(RamForest, nil, "", 0)
 	adds := make([]Leaf, nAdds)
 
 	for j, _ := range adds {
@@ -344,7 +344,7 @@ func addDelFullBatchProof(nAdds, nDels int) error {
 }
 
 func TestDeleteNonExisting(t *testing.T) {
-	f := NewForest(nil, false, "", 0)
+	f := NewForest(RamForest, nil, "", 0)
 	deletions := []uint64{0}
 	_, err := f.Modify(nil, deletions)
 	if err == nil {
@@ -358,7 +358,7 @@ func TestSmallRandomForests(t *testing.T) {
 
 	for i := 0; i < 1000; i++ {
 		// The forest instance to test in this iteration of the loop
-		f := NewForest(nil, false, "", 0)
+		f := NewForest(RamForest, nil, "", 0)
 
 		// We use 'quick' to generate testing data:
 		// we interpret the keys as leaf hashes and the values

--- a/accumulator/forestdata_test.go
+++ b/accumulator/forestdata_test.go
@@ -133,7 +133,7 @@ func createRandomHash(i int64) [32]byte {
 func TestCowForestWrite(t *testing.T) {
 	// keep only 1 treetable in memory to force flush and
 	// test the flushing/restoring as well
-	f := NewForest(nil, false, os.TempDir(), 1)
+	f := NewForest(CowForest, nil, os.TempDir(), 1)
 
 	numAdds := uint32(10)   // adds per block
 	sc := newSimChain(0x07) // A chain simulator

--- a/accumulator/pollard.go
+++ b/accumulator/pollard.go
@@ -460,7 +460,7 @@ func (p *Pollard) grabPos(
 // For debugging and seeing what pollard is doing since there's already
 // a good toString method for  forest.
 func (p *Pollard) toFull() (*Forest, error) {
-	ff := NewForest(nil, false, "", 0)
+	ff := NewForest(RamForest, nil, "", 0)
 	ff.rows = p.rows()
 	ff.numLeaves = p.numLeaves
 	ff.data = new(ramForestData)

--- a/accumulator/pollard_test.go
+++ b/accumulator/pollard_test.go
@@ -34,7 +34,7 @@ func TestPollardFixed(t *testing.T) {
 }
 
 func TestPollardSimpleIngest(t *testing.T) {
-	f := NewForest(nil, false, "", 0)
+	f := NewForest(RamForest, nil, "", 0)
 	adds := make([]Leaf, 15)
 	for i := 0; i < len(adds); i++ {
 		adds[i].Hash[0] = uint8(i + 1)
@@ -64,7 +64,7 @@ func TestPollardSimpleIngest(t *testing.T) {
 }
 
 func pollardRandomRemember(blocks int32) error {
-	f := NewForest(nil, false, "", 0)
+	f := NewForest(RamForest, nil, "", 0)
 
 	var p Pollard
 
@@ -155,7 +155,7 @@ func pollardRandomRemember(blocks int32) error {
 // fixedPollard adds and removes things in a non-random way
 func fixedPollard(leaves int32) error {
 	fmt.Printf("\t\tpollard test add %d remove 1\n", leaves)
-	f := NewForest(nil, false, "", 0)
+	f := NewForest(RamForest, nil, "", 0)
 
 	leafCounter := uint64(0)
 
@@ -220,7 +220,7 @@ func TestCache(t *testing.T) {
 	chain := newSimChain(7)
 	chain.lookahead = 8
 
-	f := NewForest(nil, false, "", 0)
+	f := NewForest(RamForest, nil, "", 0)
 	var p Pollard
 
 	// this leaf map holds all the leaves at the current height and is used to check if the pollard

--- a/accumulator/readme.md
+++ b/accumulator/readme.md
@@ -22,7 +22,7 @@ To initialize a pollard or forest:
 ```
 	// inits a Forest in memory. Refer to the documentation for NewForest() for an in-detail explanation
         // of all the different forest types.
-	forest := accumulator.NewForest(nil, false, "", 0)
+	forest := accumulator.NewForest(RamForest, nil, "", 0)
 
 	// declare pollard. No init function for pollard
 	var pollard accumulator.Pollard

--- a/accumulator/undo_test.go
+++ b/accumulator/undo_test.go
@@ -38,7 +38,7 @@ func TestUndoTest(t *testing.T) {
 }
 
 func undoOnceRandom(blocks int32) error {
-	f := NewForest(nil, false, "", 0)
+	f := NewForest(RamForest, nil, "", 0)
 
 	sc := newSimChain(0x07)
 	sc.lookahead = 0
@@ -86,7 +86,7 @@ func undoOnceRandom(blocks int32) error {
 }
 
 func undoAddDelOnce(numStart, numAdds, numDels uint32) error {
-	f := NewForest(nil, false, "", 0)
+	f := NewForest(RamForest, nil, "", 0)
 	sc := newSimChain(0xff)
 
 	// --------------- block 0

--- a/bridgenode/initrestore.go
+++ b/bridgenode/initrestore.go
@@ -149,17 +149,12 @@ func createForest(cfg *Config) (
 
 	switch cfg.forestType {
 	case ramForest:
-		forest = accumulator.NewForest(nil, false, "", 0)
+		forest = accumulator.NewForest(accumulator.RamForest, nil, "", 0)
 		return
 	case cowForest:
-		forest = accumulator.NewForest(nil, false, cfg.UtreeDir.ForestDir.cowForestDir, cfg.cowMaxCache)
+		forest = accumulator.NewForest(accumulator.CowForest, nil, cfg.UtreeDir.ForestDir.cowForestDir, cfg.cowMaxCache)
 		return
 	default:
-		var cache bool
-		if cfg.forestType == cacheForest {
-			cache = true
-		}
-
 		// Where the forestfile exists
 		forestFile, err := os.OpenFile(
 			cfg.UtreeDir.ForestDir.forestFile, os.O_CREATE|os.O_RDWR, 0600)
@@ -168,7 +163,11 @@ func createForest(cfg *Config) (
 		}
 
 		// Restores all the forest data
-		forest = accumulator.NewForest(forestFile, cache, "", 0)
+		if cfg.forestType == cacheForest {
+			forest = accumulator.NewForest(accumulator.CacheForest, forestFile, "", 0)
+		} else {
+			forest = accumulator.NewForest(accumulator.DiskForest, forestFile, "", 0)
+		}
 	}
 
 	return

--- a/csn/ibd.go
+++ b/csn/ibd.go
@@ -8,6 +8,7 @@ import (
 	"github.com/btcsuite/btcutil"
 	"github.com/mit-dci/utreexo/accumulator"
 	"github.com/mit-dci/utreexo/btcacc"
+	"github.com/mit-dci/utreexo/util"
 	uwire "github.com/mit-dci/utreexo/wire"
 )
 
@@ -148,7 +149,7 @@ func (c *Csn) putBlockInPollard(
 
 	nl, h := c.pollard.ReconstructStats()
 
-	_, outskip := ub.Block.DedupeBlock()
+	_, outCount, _, outskip := util.DedupeBlock(ub.Block)
 
 	err := ub.ProofSanity(nl, h)
 	if err != nil {
@@ -197,7 +198,7 @@ func (c *Csn) putBlockInPollard(
 
 	// get hashes to add into the accumulator
 	blockAdds := uwire.BlockToAddLeaves(
-		ub.Block, remember, outskip, ub.UtreexoData.Height)
+		ub.Block, remember, outskip, ub.UtreexoData.Height, outCount)
 	*totalTXOAdded += len(blockAdds) // for benchmarking
 
 	// Utreexo tree modification. blockAdds are the added txos and

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,3 @@ require (
 	golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9 // indirect
 	golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980 // indirect
 )
-
-replace github.com/btcsuite/btcd => github.com/mit-dci/utcd v0.21.0-beta.0.20210622094436-95ee13404deb
-replace github.com/btcsuite/btcutil => github.com/mit-dci/utcutil v1.0.3-0.20210201144513-fb3ce8742498

--- a/wire/umsgblock.go
+++ b/wire/umsgblock.go
@@ -69,10 +69,11 @@ func UblockNetworkReader(
 // right length.  Similar with skiplist, doesn't check it.
 func BlockToAddLeaves(blk *btcutil.Block,
 	remember []bool, skiplist []uint32,
-	height int32) (leaves []accumulator.Leaf) {
+	height int32, outCount int) (leaves []accumulator.Leaf) {
+
+	leaves = make([]accumulator.Leaf, 0, outCount-len(skiplist))
 
 	var txonum uint32
-	// bh := bl.Blockhash
 	for coinbaseif0, tx := range blk.Transactions() {
 		// cache txid aka txhash
 		txid := tx.Hash()
@@ -105,8 +106,6 @@ func BlockToAddLeaves(blk *btcutil.Block,
 				uleaf.Remember = remember[txonum]
 			}
 			leaves = append(leaves, uleaf)
-			// fmt.Printf("add %s\n", l.ToString())
-			// fmt.Printf("add %s -> %x\n", l.Outpoint.String(), l.LeafHash())
 			txonum++
 		}
 	}


### PR DESCRIPTION
Solves issue #294
Uses an enum as a receiver to the function `NewForest`

```go
const (
	DiskForest ForestName = iota
	RamForest
	CacheForest
	CowForest
)
```
Earlier the new forest function used function arguments to infer which type of forest is to be initialized
```go
if forestFile == nil {
		if cowPath == "" {
			// for in-ram
			f.data = new(ramForestData)
		} else {
			// Init cowForest
			d, err := initialize(cowPath, cowMaxCache)
			if err != nil {
				panic(err)
			}
			f.data = d
		}

	} else {
		// forest on disk or cached
		if cached {
			d := new(cacheForestData)
			d.file = forestFile
			d.cache = newDiskForestCache(20)
			f.data = d
		} else {
			// for on-disk
			d := new(diskForestData)
			d.file = forestFile
			f.data = d
		}
	}
```

Now the implementation has been made like this
```go
	switch fn {
	case DiskForest:
		d := new(diskForestData)
		d.file = forestFile
		f.data = d
	case RamForest:
		f.data = new(ramForestData)
	case CacheForest:
		d := new(cacheForestData)
		d.file = forestFile
		d.cache = newDiskForestCache(20)
		f.data = d
	case CowForest:
		d, err := initialize(cowPath, cowMaxCache)
		if err != nil {
			panic(err)
		}
		f.data = d
	}
```
