### PR TITLE
util/util, csn, bridgenode, wire: Use local DedupeBlock()

### DIFF
--- a/csn/ibd.go
+++ b/csn/ibd.go
@@ -8,6 +8,7 @@ import (
 	"github.com/btcsuite/btcutil"
 	"github.com/mit-dci/utreexo/accumulator"
 	"github.com/mit-dci/utreexo/btcacc"
+	"github.com/mit-dci/utreexo/util"
 	uwire "github.com/mit-dci/utreexo/wire"
 )
 
@@ -148,7 +149,7 @@ func (c *Csn) putBlockInPollard(
 
 	nl, h := c.pollard.ReconstructStats()
 
-	_, outskip := ub.Block.DedupeBlock()
+	_, outCount, _, outskip := util.DedupeBlock(ub.Block)
 
 	err := ub.ProofSanity(nl, h)
 	if err != nil {
@@ -197,7 +198,7 @@ func (c *Csn) putBlockInPollard(
 
 	// get hashes to add into the accumulator
 	blockAdds := uwire.BlockToAddLeaves(
-		ub.Block, remember, outskip, ub.UtreexoData.Height)
+		ub.Block, remember, outskip, ub.UtreexoData.Height, outCount)
 	*totalTXOAdded += len(blockAdds) // for benchmarking
 
 	// Utreexo tree modification. blockAdds are the added txos and

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,3 @@ require (
 	golang.org/x/crypto v0.0.0-20200604202706-70a84ac30bf9 // indirect
 	golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980 // indirect
 )
-
-replace github.com/btcsuite/btcd => github.com/mit-dci/utcd v0.21.0-beta.0.20210622094436-95ee13404deb
-replace github.com/btcsuite/btcutil => github.com/mit-dci/utcutil v1.0.3-0.20210201144513-fb3ce8742498

--- a/wire/umsgblock.go
+++ b/wire/umsgblock.go
@@ -69,10 +69,11 @@ func UblockNetworkReader(
 // right length.  Similar with skiplist, doesn't check it.
 func BlockToAddLeaves(blk *btcutil.Block,
 	remember []bool, skiplist []uint32,
-	height int32) (leaves []accumulator.Leaf) {
+	height int32, outCount int) (leaves []accumulator.Leaf) {
+
+	leaves = make([]accumulator.Leaf, 0, outCount-len(skiplist))
 
 	var txonum uint32
-	// bh := bl.Blockhash
 	for coinbaseif0, tx := range blk.Transactions() {
 		// cache txid aka txhash
 		txid := tx.Hash()
@@ -105,8 +106,6 @@ func BlockToAddLeaves(blk *btcutil.Block,
 				uleaf.Remember = remember[txonum]
 			}
 			leaves = append(leaves, uleaf)
-			// fmt.Printf("add %s\n", l.ToString())
-			// fmt.Printf("add %s -> %x\n", l.Outpoint.String(), l.LeafHash())
 			txonum++
 		}
 	}


### PR DESCRIPTION
Use local DedupeBlock() to remove utcutil and utcd dependency. The
utreexo repository is now only dependent on the default btcd repository.

DedupeBlock() now also returns the count of all the inputs and outputs.
This let's callers pre-allocate slices to the required length improving
memory allcation efficiency.

## Note

This will make the `utreexoclient` and `utreexoserver` binaries a bit slower since they are now linked to the btcd repo without all the performance improvements I have added in. The eventual plan would be to link it to utcd, when things are a bit more stable.