### PR TITLE
add support for signet

### DIFF
--- a/bridgenode/config.go
+++ b/bridgenode/config.go
@@ -18,6 +18,7 @@ The bridgenode server generates proofs and serves to the CSN node.
 OPTIONS:
   -net=mainnet                 configure whether to use mainnet. Optional.
   -net=regtest                 configure whether to use regtest. Optional.
+  -net=signet                 configure whether to use signet. Optional.
   -forest                      select forest type to use (ram, cow, cache, disk). Defaults to disk
   -datadir="path/to/directory" set a custom DATADIR.
                                Defaults to the Bitcoin Core DATADIR path
@@ -34,7 +35,7 @@ OPTIONS:
 var (
 	argCmd = flag.NewFlagSet("", flag.ExitOnError)
 	netCmd = argCmd.String("net", "testnet",
-		"Target network. (testnet, regtest, mainnet) Usage: '-net=regtest'")
+		"Target network. (testnet, signet, regtest, mainnet) Usage: '-net=regtest'")
 	dataDirCmd = argCmd.String("datadir", "",
 		`Set a custom datadir. Usage: "-datadir='path/to/directory'"`)
 	bridgeDirCmd = argCmd.String("bridgedir", "",
@@ -261,6 +262,13 @@ func Parse(args []string) (*Config, error) {
 		cfg.params = chaincfg.MainNetParams
 		cfg.BlockDir = filepath.Join(dataDir, "blocks")
 		cfg.UtreeDir = initUtreeDir(bridgeDir)
+	} else if *netCmd == "signet" {
+		cfg.params = chaincfg.SigNetParams
+		cfg.BlockDir = filepath.Join(
+			filepath.Join(dataDir, chaincfg.SigNetParams.Name),
+			"blocks")
+		base := filepath.Join(bridgeDir, chaincfg.SigNetParams.Name)
+		cfg.UtreeDir = initUtreeDir(base)
 	} else {
 		return nil, errInvalidNetwork(*netCmd)
 	}

--- a/bridgenode/offsetfile.go
+++ b/bridgenode/offsetfile.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"crypto/sha256"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -201,6 +202,10 @@ func writeBlockOffset(
 	util.Hash, int32, error) {
 
 	wr.Reset(offsetFile)
+
+	if len(blockHeaders) == 0 {
+		return tip, tipnum, errBuildProofs(errors.New("no block headers found"))
+	}
 
 	for _, b := range blockHeaders {
 		if len(nextMap) > 10000 { //Just a random big number

--- a/csn/config.go
+++ b/csn/config.go
@@ -18,6 +18,7 @@ You can give a bech32 address to watch during IBD.
 OPTIONS:
   -net=mainnet                 configure whether to use mainnet. Optional.
   -net=regtest                 configure whether to use regtest. Optional.
+  -net=signet                 configure whether to use signet. Optional.
 
   -cpuprof                     configure whether to use use cpu profiling
   -memprof                     configure whether to use use heap profiling
@@ -31,7 +32,7 @@ OPTIONS:
 var (
 	argCmd = flag.NewFlagSet("", flag.ExitOnError)
 	netCmd = argCmd.String("net", "testnet",
-		"Target network. (testnet, regtest, mainnet) Usage: '-net=regtest'")
+		"Target network. (testnet, signet, regtest, mainnet) Usage: '-net=regtest'")
 	cpuProfCmd = argCmd.String("cpuprof", "",
 		`Enable pprof cpu profiling. Usage: 'cpuprof='path/to/file'`)
 	memProfCmd = argCmd.String("memprof", "",
@@ -95,6 +96,8 @@ func Parse(args []string) (*Config, error) {
 		cfg.params = chaincfg.RegressionNetParams
 	} else if *netCmd == "mainnet" {
 		cfg.params = chaincfg.MainNetParams
+	} else if *netCmd == "signet" {
+		cfg.params = chaincfg.SigNetParams
 	} else {
 		return nil, errInvalidNetwork(*netCmd)
 	}

--- a/util/utils.go
+++ b/util/utils.go
@@ -37,6 +37,13 @@ var regTestGenHash = Hash{
 	0xc7, 0xb2, 0xb7, 0x3c, 0xf1, 0x88, 0x91, 0x0f,
 }
 
+var sigNetGenHash = Hash{
+	0xf6, 0x1e, 0xee, 0x3b, 0x63, 0xa3, 0x80, 0xa4,
+	0x77, 0xa0, 0x63, 0xaf, 0x32, 0xb2, 0xbb, 0xc9,
+	0x7c, 0x9f, 0xf9, 0xf0, 0x1f, 0x2c, 0x42, 0x25,
+	0xe9, 0x73, 0x98, 0x81, 0x08, 0x00, 0x00, 0x00,
+}
+
 // For a given BitcoinNet, yields the genesis hash
 // If the BitcoinNet is not supported, an error is
 // returned.
@@ -49,6 +56,8 @@ func GenHashForNet(p chaincfg.Params) (*Hash, error) {
 		return &mainNetGenHash, nil
 	case "regtest":
 		return &regTestGenHash, nil
+	case "signet":
+		return &sigNetGenHash, nil
 	}
 	return nil, fmt.Errorf("net not supported")
 }
@@ -182,7 +191,8 @@ func PopPrefixLen16(b []byte) ([]byte, []byte, error) {
 func CheckMagicByte(bytesgiven []byte) bool {
 	if bytes.Compare(bytesgiven, []byte{0x0b, 0x11, 0x09, 0x07}) != 0 && //testnet
 		bytes.Compare(bytesgiven, []byte{0xf9, 0xbe, 0xb4, 0xd9}) != 0 && // mainnet
-		bytes.Compare(bytesgiven, []byte{0xfa, 0xbf, 0xb5, 0xda}) != 0 { // regtest
+		bytes.Compare(bytesgiven, []byte{0xfa, 0xbf, 0xb5, 0xda}) != 0 && // regtest
+		bytes.Compare(bytesgiven, []byte{0x0a, 0x03, 0xcf, 0x40}) != 0 { // signet
 		fmt.Printf("got non magic bytes %x, finishing\n", bytesgiven)
 		return false
 	}


### PR DESCRIPTION
This PR is supposed to add support for SigNet [🔗](https://en.bitcoin.it/wiki/Signet) to facilitate a smaller and simpler development environment.

EDIT: 
This PR will enable users to test and develop utreexo on very minimal system requirements. The total storage space required for signet is `190MiB` and the size of .utreexo/signet is `132MiB`.