### PR TITLE
feature for saving undoBlocks (IN Progress)

### DIFF
--- a/accumulator/forest.go
+++ b/accumulator/forest.go
@@ -405,7 +405,7 @@ func (f *Forest) addv2(adds []Leaf) {
 // Note that this does not modify in place!  All deletes occur simultaneous with
 // adds, which show up on the right.
 // Also, the deletes need there to be correct proof data, so you should first call Verify().
-func (f *Forest) Modify(adds []Leaf, delsUn []uint64) (*undoBlock, error) {
+func (f *Forest) Modify(adds []Leaf, delsUn []uint64) (*UndoBlock, error) {
 	numdels, numadds := len(delsUn), len(adds)
 	delta := int64(numadds - numdels) // watch 32/64 bit
 	if int64(f.numLeaves)+delta < 0 {

--- a/accumulator/undo.go
+++ b/accumulator/undo.go
@@ -13,14 +13,14 @@ although actually it can make sense for non-bridge nodes to undo as well...
 
 // blockUndo is all the data needed to undo a block: number of adds,
 // and all the hashes that got deleted and where they were from
-type undoBlock struct {
+type UndoBlock struct {
 	numAdds   uint32   // number of adds in the block
 	positions []uint64 // position of all deletions this block
 	hashes    []Hash   // hashes that were deleted
 }
 
 // ToString returns a string
-func (u *undoBlock) ToString() string {
+func (u *UndoBlock) ToString() string {
 	s := fmt.Sprintf("- uuuu undo block %d adds\t", u.numAdds)
 	s += fmt.Sprintf("%d dels:\t", len(u.positions))
 	if len(u.positions) != len(u.hashes) {
@@ -34,8 +34,8 @@ func (u *undoBlock) ToString() string {
 	return s
 }
 
-// Undo reverts a Modify() with the given undoBlock.
-func (f *Forest) Undo(ub undoBlock) error {
+// Undo reverts a Modify() with the given UndoBlock.
+func (f *Forest) Undo(ub UndoBlock) error {
 	prevAdds := uint64(ub.numAdds)
 	prevDels := uint64(len(ub.hashes))
 	// how many leaves were there at the last block?
@@ -60,7 +60,7 @@ func (f *Forest) Undo(ub undoBlock) error {
 	// forest bounds to the right; they will be shuffled in to the left.
 	for i, h := range ub.hashes {
 		if h == empty {
-			return fmt.Errorf("hash %d in undoblock is empty", i)
+			return fmt.Errorf("hash %d in UndoBlock is empty", i)
 		}
 		f.data.write(f.numLeaves+uint64(i), h)
 		dirt = append(dirt, f.numLeaves+uint64(i))
@@ -103,9 +103,9 @@ func (f *Forest) Undo(ub undoBlock) error {
 	return nil
 }
 
-// BuildUndoData makes an undoBlock from the same data that you'd give to Modify
-func (f *Forest) BuildUndoData(numadds uint64, dels []uint64) *undoBlock {
-	ub := new(undoBlock)
+// BuildUndoData makes an UndoBlock from the same data that you'd give to Modify
+func (f *Forest) BuildUndoData(numadds uint64, dels []uint64) *UndoBlock {
+	ub := new(UndoBlock)
 	ub.numAdds = uint32(numadds)
 
 	ub.positions = dels // the deletion positions, in sorted order

--- a/bridgenode/flatfileworker.go
+++ b/bridgenode/flatfileworker.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"sync"
 
+	"github.com/mit-dci/utreexo/accumulator"
 	"github.com/mit-dci/utreexo/btcacc"
 )
 
@@ -60,6 +61,7 @@ type flatFileState struct {
 func flatFileWorker(
 	proofChan chan btcacc.UData,
 	ttlResultChan chan ttlResultBlock,
+	UndoBlockChan chan accumulator.UndoBlock,
 	utreeDir utreeDir,
 	fileWait *sync.WaitGroup) {
 

--- a/bridgenode/genproofs.go
+++ b/bridgenode/genproofs.go
@@ -160,12 +160,12 @@ func BuildProofs(cfg *Config, sig chan bool) error {
 
 		// TODO: Don't ignore UndoBlock
 		// Modifies the forest with the given TXINs and TXOUTs
-		undo, err = forest.Modify(blockAdds, ud.AccProof.Targets)
+		undo, err := forest.Modify(blockAdds, ud.AccProof.Targets)
 		if err != nil {
 			return err
 		}
 
-		undoChan <- undo
+		undoChan <- *undo
 
 		if bnr.Height%100 == 0 {
 			fmt.Println("On block :", bnr.Height+1)

--- a/bridgenode/offsetfile.go
+++ b/bridgenode/offsetfile.go
@@ -224,7 +224,7 @@ func writeBlockOffset(
 		undoOffset := make([]byte, 4)
 		binary.BigEndian.PutUint32(undoOffset, b.UndoPos)
 
-		// write undoblock offset
+		// write UndoBlock offset
 		wr.Write(undoOffset)
 
 		// set the tip to current block's hash
@@ -247,7 +247,7 @@ func writeBlockOffset(
 			sUndoOffset := make([]byte, 4)
 			binary.BigEndian.PutUint32(sUndoOffset, stashedBlock.UndoPos)
 
-			// write undoblock offset
+			// write UndoBlock offset
 			wr.Write(sUndoOffset)
 
 			// set the tip to current block's hash


### PR DESCRIPTION
This PR is for saving the undoblocks data returned from forest.Modify  from the BuildProofs function in the genproofs.go file.

A new channel of undo unBlock type has been created where the undoblocks are passed which is then sent to flatfileworker .

Undoblocks a method is added to serialize them into bytes.

ToDo -> hanlde case to save the undoblocks within the flatfileworker function