### PR TITLE
csn/ibd: Don't set UTXOs to be remembered

### DIFF
--- a/csn/ibd.go
+++ b/csn/ibd.go
@@ -192,8 +192,12 @@ func (c *Csn) putBlockInPollard(
 
 	remember := make([]bool, len(ub.UtreexoData.TxoTTLs))
 	for i, ttl := range ub.UtreexoData.TxoTTLs {
-		// ttl-ub.Height is the number of blocks until the block is spend.
-		remember[i] = ttl < c.pollard.Lookahead
+		// 0 means that it's a UTXO. Don't remember.
+		if ttl == 0 {
+			remember[i] = false
+		} else {
+			remember[i] = ttl < c.pollard.Lookahead
+		}
 	}
 
 	// get hashes to add into the accumulator

--- a/util/utils.go
+++ b/util/utils.go
@@ -138,7 +138,7 @@ func DedupeBlock(blk *btcutil.Block) (inCount, outCount int, inskip []uint32, ou
 	for coinbase, tx := range blk.Transactions() {
 		txOut := tx.MsgTx().TxOut
 		if coinbase == 0 { // coinbase tx can't be deduped
-			i += uint32(len(txOut)) // coinbase can have multiple inputs
+			i += uint32(len(txOut)) // coinbase can have multiple outputs
 			continue
 		}
 

--- a/wire/umsgblock.go
+++ b/wire/umsgblock.go
@@ -71,6 +71,8 @@ func BlockToAddLeaves(blk *btcutil.Block,
 	remember []bool, skiplist []uint32,
 	height int32, outCount int) (leaves []accumulator.Leaf) {
 
+	// We're overallocating a little bit since all the unspendables
+	// won't be appended. It's ok though for the pre-allocation savings.
 	leaves = make([]accumulator.Leaf, 0, outCount-len(skiplist))
 
 	var txonum uint32


### PR DESCRIPTION
UTXOs are currently marked with ttl value of 0. Since 0 < 1000 is true,
the pollard was remembering all the UTXOs ever, leading to a ton of
memory usage. With this change, CSNs see a lot less memory usage.

This PR still sees the remembered leaves growing over time
so there might still be a problem yet to be fixed.