### PR TITLE
Saving UndoBlocks in Undoblock directory

### DIFF
--- a/accumulator/undo.go
+++ b/accumulator/undo.go
@@ -16,6 +16,7 @@ although actually it can make sense for non-bridge nodes to undo as well...
 // blockUndo is all the data needed to undo a block: number of adds,
 // and all the hashes that got deleted and where they were from
 type UndoBlock struct {
+	Height    int32    // height of block
 	numAdds   uint32   // number of adds in the block
 	positions []uint64 // position of all deletions this block
 	hashes    []Hash   // hashes that were deleted

--- a/bridgenode/config.go
+++ b/bridgenode/config.go
@@ -88,11 +88,18 @@ type offsetDir struct {
 	lastIndexOffsetHeightFile string
 }
 
+type undoDir struct {
+	base       string
+	undoFile   string
+	offsetFile string
+}
+
 // All your utreexo bridgenode file paths in a nice and convinent struct
 type utreeDir struct {
 	OffsetDir offsetDir
 	ProofDir  proofDir
 	ForestDir forestDir
+	UndoDir   undoDir
 	Ttldb     string
 }
 
@@ -124,12 +131,20 @@ func initUtreeDir(basePath string) utreeDir {
 		cowForestCurFile:                filepath.Join(cowDir, "CURRENT"),
 	}
 
+	undoBase := filepath.Join(basePath, "undoblockdata")
+	undo := undoDir{
+		base:       undoBase,
+		undoFile:   filepath.Join(undoBase, "undo.dat"),
+		offsetFile: filepath.Join(undoBase, "offset.dat"),
+	}
+
 	ttldb := filepath.Join(basePath, "ttldb")
 
 	return utreeDir{
 		OffsetDir: off,
 		ProofDir:  proof,
 		ForestDir: forest,
+		UndoDir:   undo,
 		Ttldb:     ttldb,
 	}
 }
@@ -149,6 +164,10 @@ func makePaths(dir utreeDir) error {
 		return fmt.Errorf("init makePaths error %s")
 	}
 	err = os.MkdirAll(dir.ForestDir.cowForestDir, os.ModePerm)
+	if err != nil {
+		return fmt.Errorf("init makePaths error %s")
+	}
+	err = os.MkdirAll(dir.UndoDir.base, os.ModePerm)
 	if err != nil {
 		return fmt.Errorf("init makePaths error %s")
 	}


### PR DESCRIPTION
This PR is for saving the undoblocks data returned from forest.Modify from the BuildProofs function in the genproofs.go file.

A new channel of undo unBlock type has been created where the undoblocks are passed which is then sent to flatfileworker .

a new parameter for undoBlocks height is added

config for undoBlock directory is added 
