### PR TITLE
Saving TTL data seperately

### DIFF
--- a/bridgenode/config.go
+++ b/bridgenode/config.go
@@ -94,6 +94,11 @@ type undoDir struct {
 	undoFile   string
 	offsetFile string
 }
+type ttlDir struct {
+	base       string
+	ttlsetFile string
+	OffsetFile string
+}
 
 // All your utreexo bridgenode file paths in a nice and convinent struct
 type utreeDir struct {
@@ -101,6 +106,7 @@ type utreeDir struct {
 	ProofDir  proofDir
 	ForestDir forestDir
 	UndoDir   undoDir
+	TtlDir    ttlDir
 	Ttldb     string
 }
 
@@ -139,6 +145,12 @@ func initUtreeDir(basePath string) utreeDir {
 		offsetFile: filepath.Join(undoBase, "offset.dat"),
 	}
 
+	ttlBase := filepath.Join(basePath, "ttldata")
+	ttl := ttlDir{
+		base:       ttlBase,
+		ttlsetFile: filepath.Join(ttlBase, "ttldata.dat"),
+		OffsetFile: filepath.Join(ttlBase, "offsetfile.dat"),
+	}
 	ttldb := filepath.Join(basePath, "ttldb")
 
 	return utreeDir{
@@ -146,6 +158,7 @@ func initUtreeDir(basePath string) utreeDir {
 		ProofDir:  proof,
 		ForestDir: forest,
 		UndoDir:   undo,
+		TtlDir:    ttl,
 		Ttldb:     ttldb,
 	}
 }
@@ -169,6 +182,10 @@ func makePaths(dir utreeDir) error {
 		return fmt.Errorf("init makePaths error %s")
 	}
 	err = os.MkdirAll(dir.UndoDir.base, os.ModePerm)
+	if err != nil {
+		return fmt.Errorf("init makePaths error %s")
+	}
+	err = os.MkdirAll(dir.TtlDir.base, os.ModePerm)
 	if err != nil {
 		return fmt.Errorf("init makePaths error %s")
 	}

--- a/bridgenode/flatfileworker.go
+++ b/bridgenode/flatfileworker.go
@@ -151,14 +151,6 @@ func flatFileWorker(
 				panic(err)
 			}
 		case ttlRes := <-ttlResultChan:
-			for ttlRes.Height > ff.currentHeight {
-				ud := <-proofChan
-				err = ff.writeProofBlock(ud)
-				if err != nil {
-					panic(err)
-				}
-			}
-
 			err = tf.writeTTLs(ttlRes)
 			if err != nil {
 				panic(err)

--- a/bridgenode/flatfileworker.go
+++ b/bridgenode/flatfileworker.go
@@ -164,6 +164,7 @@ func flatFileWorker(
 		case size := <-leafblockChan:
 			bytesTtlWrite := make([]byte, size)
 			_, err := tf.proofFile.WriteAt(bytesTtlWrite, tf.currentOffset)
+			tf.fileWait.Done()
 			if err != nil {
 				panic(err)
 			}

--- a/bridgenode/flatfileworker.go
+++ b/bridgenode/flatfileworker.go
@@ -172,9 +172,10 @@ func flatFileWorkerTTlBlocks(
 		if err != nil {
 			panic(err)
 		}
-		tf.currentOffset = tf.currentOffset + int64(size*4)
 		// append tf offsets after writing ttl data
 		tf.offsets = append(tf.offsets, tf.currentOffset)
+		// increment currentoffset value
+		tf.currentOffset = tf.currentOffset + int64(size*4)
 	}
 
 }

--- a/bridgenode/flatfileworker.go
+++ b/bridgenode/flatfileworker.go
@@ -107,6 +107,27 @@ func flatFileWorker(
 	if err != nil {
 		panic(err)
 	}
+	// ttl data saving initialization
+	var tf flatFileState
+
+	tf.offsetFile, err = os.OpenFile(
+		utreeDir.TtlDir.OffsetFile, os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		panic(err)
+	}
+
+	tf.proofFile, err = os.OpenFile(
+		utreeDir.TtlDir.ttlsetFile, os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		panic(err)
+	}
+	tf.fileWait = fileWait
+
+	err = tf.ffInit()
+	if err != nil {
+		panic(err)
+	}
+
 	// Grab either proof bytes and write em to offset / proof file, OR, get a TTL result
 	// and write that.  Will this lock up if it keeps doing proofs and ignores ttls?
 	// it should keep both buffers about even.  If it keeps doing proofs and the ttl
@@ -138,7 +159,7 @@ func flatFileWorker(
 				}
 			}
 
-			err = ff.writeTTLs(ttlRes)
+			err = tf.writeTTLs(ttlRes)
 			if err != nil {
 				panic(err)
 			}

--- a/bridgenode/genproofs.go
+++ b/bridgenode/genproofs.go
@@ -112,7 +112,9 @@ func BuildProofs(cfg *Config, sig chan bool) error {
 
 	var fileWait sync.WaitGroup
 
-	go flatFileWorker(proofChan, ttlResultChan, undoChan, leafblockChan, cfg.UtreeDir, &fileWait)
+	go flatFileWorkerProofBlocks(proofChan, cfg.UtreeDir, &fileWait)                  // flat file worker for proof blocks
+	go flatFileWorkerUndoBlocks(undoChan, cfg.UtreeDir, &fileWait)                    // flat file worker for the undo blocks
+	go flatFileWorkerTTlBlocks(ttlResultChan, leafblockChan, cfg.UtreeDir, &fileWait) // flat file worker for the ttl blocks
 
 	fmt.Println("Building Proofs and ttldb...")
 


### PR DESCRIPTION
In this PR a new config for ttl directory has been added and ttl data are being stored in a new flatfilestate in the flatfileworker.go