### PR TITLE
Fuzz forest / undo

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -120,3 +120,69 @@ jobs:
       run: |
         cd $GOPATH/src/github.com/${{ github.repository }}
         ./test/check_proofs_backwards.sh utreexoserver "${{ github.workspace }}"
+
+  fuzz:
+    name: Fuzz
+    runs-on: ubuntu-latest
+    needs: Build
+    timeout-minutes: 5
+    steps:
+
+    - name: setup directory
+      shell: bash
+      run: |
+        mkdir -p "${{ github.workspace }}/fuzz-coverage"
+
+    # set GOPATH
+    - name: setup env
+      shell: bash
+      run: |
+        echo "${{ github.workspace }}/go/bin:" >> $GITHUB_PATH
+        echo "GOPATH=${{ github.workspace }}/go" >> $GITHUB_ENV
+
+    - name: Install Go
+      if: success()
+      uses: actions/setup-go@v1
+      with:
+        # go install doesn't work with 1.13
+        go-version: 1.17
+      id: go
+
+    - name: checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+        path: go/src/github.com/${{ github.repository }}
+
+    - name: Get dependencies
+      run: |
+        cd $GOPATH/src/github.com/${{ github.repository }}
+        go get -v -d ./...
+
+    - name: Install fuzzer
+      shell: bash
+      run: |
+        go install github.com/dvyukov/go-fuzz/go-fuzz@latest github.com/dvyukov/go-fuzz/go-fuzz-build@latest
+        go get github.com/dvyukov/go-fuzz/go-fuzz-dep
+
+    - name: Build
+      shell: bash
+      run: |
+        cd $GOPATH/src/github.com/${{ github.repository }}/accumulator
+        go-fuzz-build
+
+    - name: Fuzz
+      shell: bash
+      run: |
+        cd $GOPATH/src/github.com/${{ github.repository }}/accumulator
+        timeout --preserve-status --signal INT 120s go-fuzz -dumpcover |& tee fuzz.log
+        grep "crashers: 0," fuzz.log > /dev/null
+        sed -i '/0.0,1.1/d' coverprofile
+        cp coverprofile "${{ github.workspace }}/fuzz-coverage/"
+        go tool cover -html=coverprofile -o "${{ github.workspace }}/fuzz-coverage/cover.html"
+
+    - name: Fuzz coverage
+      uses: actions/upload-artifact@v2
+      with:
+        name: fuzz-coverage
+        path: "${{ github.workspace }}/fuzz-coverage"

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,9 @@ cmd/simcmd/simcmd
 cmd/utreexoclient/utreexoclient
 cmd/utreexoserver/utreexoserver
 cmd/utreexoclient/pollardFile 
+/accumulator/corpus/
+/accumulator/crashers/
+/accumulator/suppressions/
+/accumulator/accumulator-fuzz.zip
+/accumulator/coverprofile
+/accumulator/sonarprofile

--- a/accumulator/fuzz.go
+++ b/accumulator/fuzz.go
@@ -1,0 +1,73 @@
+//go:build gofuzz
+// +build gofuzz
+
+package accumulator
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+)
+
+func undoOnceFuzzy(data *bytes.Buffer) error {
+	f := NewForest(RamForest, nil, "", 0)
+
+	seed0, err := data.ReadByte();
+	if err != nil { return nil }
+	seed1, err := data.ReadByte();
+	if err != nil { return nil }
+	seed := (int64(seed1) << 8) | int64(seed0)
+	sc := newSimChainWithSeed(0x07, seed)
+	if sc == nil {
+		return nil
+	}
+	sc.lookahead = 0
+	for b := int32(0); ; b++ {
+		numAdds, err := data.ReadByte()
+		if err != nil {
+			break
+		}
+		numAdds &= 0x1f
+
+		adds, durations, delHashes := sc.NextBlock(uint32(numAdds))
+
+		bp, err := f.ProveBatch(delHashes)
+		if err != nil {
+			return err
+		}
+		beforeRoot := f.getRoots()
+		ub, err := f.Modify(adds, bp.Targets)
+		if err != nil {
+			return err
+		}
+		err = f.PosMapSanity()
+		if err != nil {
+			return err
+		}
+
+		// undo every 3rd block
+		if b%3 == 2 {
+			err := f.Undo(*ub)
+			if err != nil {
+				return err
+			}
+			sc.BackOne(adds, durations, delHashes)
+			afterRoot := f.getRoots()
+			if !reflect.DeepEqual(beforeRoot, afterRoot) {
+				return fmt.Errorf("undo mismatch")
+			}
+		}
+
+	}
+	return nil
+}
+
+func Fuzz(dataBytes []byte) int {
+	data := bytes.NewBuffer(dataBytes)
+
+	err := undoOnceFuzzy(data)
+	if err != nil {
+		panic("failed")
+	}
+	return 1
+}

--- a/accumulator/types.go
+++ b/accumulator/types.go
@@ -108,11 +108,13 @@ func (s *simChain) BackOne(leaves []Leaf, durations []int32, dels []Hash) {
 		if durations[i] == 0 {
 			continue
 		}
-		fmt.Printf("removing %x at end of row %d\n", l.Hash[:4], durations[i])
-		// everything should be in order, right?
-		fmt.Printf("remove %x from end of ttl slice %d\n",
-			s.ttlSlices[durations[i]][len(s.ttlSlices[durations[i]])-1][:4],
-			durations[i])
+		if verbose {
+			fmt.Printf("removing %x at end of row %d\n", l.Hash[:4], durations[i])
+			// everything should be in order, right?
+			fmt.Printf("remove %x from end of ttl slice %d\n",
+				s.ttlSlices[durations[i]][len(s.ttlSlices[durations[i]])-1][:4],
+				durations[i])
+		}
 		s.ttlSlices[durations[i]] =
 			s.ttlSlices[durations[i]][:len(s.ttlSlices[durations[i]])-1]
 	}
@@ -137,7 +139,10 @@ func (s *simChain) ttlString() string {
 // to be outputed
 func (s *simChain) NextBlock(numAdds uint32) ([]Leaf, []int32, []Hash) {
 	s.blockHeight++
-	fmt.Printf("blockHeight %d\n", s.blockHeight)
+	if verbose {
+		fmt.Printf(
+			"blockHeight %d\n", s.blockHeight)
+	}
 
 	if s.blockHeight == 0 && numAdds == 0 {
 		numAdds = 1

--- a/accumulator/types.go
+++ b/accumulator/types.go
@@ -85,6 +85,7 @@ type simChain struct {
 	leafCounter  uint64
 	durationMask uint32
 	lookahead    int32
+	rnd          *rand.Rand
 }
 
 // newSimChain initializes and returns a simchain
@@ -93,6 +94,17 @@ func newSimChain(duration uint32) *simChain {
 	s.blockHeight = -1
 	s.durationMask = duration
 	s.ttlSlices = make([][]Hash, s.durationMask+1)
+	s.rnd = rand.New(rand.NewSource(0))
+	return &s
+}
+
+// newSimChainWithSeed initializes and returns a simchain, with an externally supplied seed
+func newSimChainWithSeed(duration uint32, seed int64) *simChain {
+	var s simChain
+	s.blockHeight = -1
+	s.durationMask = duration
+	s.ttlSlices = make([][]Hash, s.durationMask+1)
+	s.rnd = rand.New(rand.NewSource(seed))
 	return &s
 }
 
@@ -165,7 +177,7 @@ func (s *simChain) NextBlock(numAdds uint32) ([]Leaf, []int32, []Hash) {
 		adds[j].Hash[4] = uint8(s.leafCounter >> 24)
 		adds[j].Hash[5] = uint8(s.leafCounter >> 32)
 
-		durations[j] = int32(rand.Uint32() & s.durationMask)
+		durations[j] = int32(s.rnd.Uint32() & s.durationMask)
 
 		// with "+1", the duration is 1 to 256, so the forest never gets
 		// big or tall.  Without the +1, the duration is sometimes 0,

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/adiabat/bech32 v0.0.0-20170505011816-6289d404861d
 	github.com/btcsuite/btcd v0.21.0-beta.0.20201124191514-610bb55ae85c
 	github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce
+	github.com/dvyukov/go-fuzz v0.0.0-20210914135545-4980593459a1 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20200815110645-5c35d600f0ca
 )
 

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/decred/dcrd/lru v1.0.0/go.mod h1:mxKOwFd7lFjN2GZYsiz/ecgqR6kkYAl+0pz0tEMk218=
+github.com/dvyukov/go-fuzz v0.0.0-20210914135545-4980593459a1 h1:YQOLTC8zvFaNSEuMexG0i7pY26bOksnQFsSJfGclo54=
+github.com/dvyukov/go-fuzz v0.0.0-20210914135545-4980593459a1/go.mod h1:11Gm+ccJnvAhCNLlf5+cS9KjtbaD5I5zaZpFMsTHWTw=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=


### PR DESCRIPTION
TODO:

- [x] ensure that fuzzer job fails if crashes are found
- [x] DRY with existing SimChain

A simple fuzzer using [go-fuzz](https://github.com/dvyukov/go-fuzz).

- implement a fuzzer for forest / undo
- add a check that undo produces the same roots that were there before the block

This is probably not optimal - i.e. the execution time of each try could be reduced.

It also doesn't cover all of the branches after about 12 hours of CPU time - can be seen in the coverage.

Usage:

```shell
go install github.com/dvyukov/go-fuzz/go-fuzz@latest
go get github.com/dvyukov/go-fuzz/go-fuzz-dep
cd accumulator
go-fuzz-build
go-fuzz
```

Coverage:
```shell
go-fuzz -dumpcover
# `go tool cover` may fail due to a bug - you might need to remove a line that looks like:
# ...accumulator/forest.go:0.0,1.1 0 0
# as well as all lines that refer to files outside the repo
go tool cover -html=coverprofile
```