### PR TITLE
accumulator/pollard: Add support for multi-block proofs

### DIFF
--- a/accumulator/pollardfull_test.go
+++ b/accumulator/pollardfull_test.go
@@ -46,7 +46,7 @@ func pollardFullRandomRemember(blocks int32) error {
 		}
 
 		// verify proofs on rad node
-		err = p.IngestBatchProof(delHashes, bp)
+		err = p.IngestBatchProof(delHashes, bp, false)
 		if err != nil {
 			return err
 		}

--- a/csn/ibd.go
+++ b/csn/ibd.go
@@ -185,7 +185,7 @@ func (c *Csn) putBlockInPollard(
 	}
 
 	// Fills in the empty(nil) nieces for verification && deletion
-	err = c.pollard.IngestBatchProof(delHashes, ub.UtreexoData.AccProof)
+	err = c.pollard.IngestBatchProof(delHashes, ub.UtreexoData.AccProof, false)
 	if err != nil {
 		fmt.Printf("height %d ingest error\n", ub.UtreexoData.Height)
 		fmt.Printf("proof %s\n", ub.UtreexoData.AccProof.ToString())


### PR DESCRIPTION
IngestBatchProof now takes in a `rememberAll` argument. When it is
true, IngestBatchProof will mark all of the proof to be remembered.

The functionality is tested by a new function,
`TestPollardIngestMultiBlockProof` which has the forest generate proofs
in a certain interval.

NOTE: There hasn't been much testing to check that all nodes that should
be forgotten have been forgotten after the pollard is done deleting all
the nodes the proof was for.

Furthermore, there needs to be code to forget the proofs if the
batchproof was lying about what leaves will be deleted in the future.