### PR TITLE
accumulator/forest: Export getroots function

### DIFF
--- a/accumulator/forest.go
+++ b/accumulator/forest.go
@@ -677,8 +677,8 @@ func (f *Forest) WriteForestToDisk(dumpFile *os.File, ram, cow bool) error {
 	return nil
 }
 
-// getRoots returns all the roots of the trees
-func (f *Forest) getRoots() []Hash {
+// GetRoots returns all the roots of all the trees in the accumulator.
+func (f *Forest) GetRoots() []Hash {
 	positionList := NewPositionList()
 	defer positionList.Free()
 
@@ -712,7 +712,7 @@ func (f *Forest) ToString() string {
 	// tree rows should be 6 or less
 	if fh > 6 {
 		s := fmt.Sprintf("can't print %d leaves. roots:\n", f.numLeaves)
-		roots := f.getRoots()
+		roots := f.GetRoots()
 		for i, r := range roots {
 			s += fmt.Sprintf("\t%d %x\n", i, r.Mini())
 		}

--- a/accumulator/forest_test.go
+++ b/accumulator/forest_test.go
@@ -271,7 +271,7 @@ func addDelFullBatchProof(nAdds, nDels int) error {
 		return err
 	}
 	// check block proof.  Note this doesn't delete anything, just proves inclusion
-	_, _, err = verifyBatchProof(leavesToProve, bp, f.getRoots(), f.numLeaves, nil)
+	_, _, err = verifyBatchProof(leavesToProve, bp, f.GetRoots(), f.numLeaves, nil)
 	if err != nil {
 		return fmt.Errorf("VerifyBatchProof failed. Error: %s", err.Error())
 	}

--- a/accumulator/forestproofs.go
+++ b/accumulator/forestproofs.go
@@ -199,6 +199,6 @@ func (f *Forest) ProveBatch(hs []Hash) (BatchProof, error) {
 
 // VerifyBatchProof is just a wrapper around verifyBatchProof
 func (f *Forest) VerifyBatchProof(toProve []Hash, bp BatchProof) error {
-	_, _, err := verifyBatchProof(toProve, bp, f.getRoots(), f.numLeaves, nil)
+	_, _, err := verifyBatchProof(toProve, bp, f.GetRoots(), f.numLeaves, nil)
 	return err
 }

--- a/accumulator/pollard_test.go
+++ b/accumulator/pollard_test.go
@@ -121,7 +121,7 @@ func pollardRandomRemember(blocks int32) error {
 			return fmt.Errorf("pollard and forest leaves differ")
 		}
 
-		fullTops := f.getRoots()
+		fullTops := f.GetRoots()
 		polTops := p.rootHashesForward()
 
 		// check that tops match
@@ -269,7 +269,7 @@ func TestPollardIngestMultiBlockProof(t *testing.T) {
 				t.Fatal(fmt.Errorf("Pollard and forest leaves differ"))
 			}
 
-			forestRoots := f.getRoots()
+			forestRoots := f.GetRoots()
 			pollardRoots := p.rootHashesForward()
 
 			// Check that roots match.

--- a/accumulator/undo_test.go
+++ b/accumulator/undo_test.go
@@ -159,7 +159,7 @@ func undoOnceRandom(blocks int32) error {
 		if err != nil {
 			return err
 		}
-		beforeRoot := f.getRoots()
+		beforeRoot := f.GetRoots()
 		ub, err := f.Modify(adds, bp.Targets)
 		if err != nil {
 			return err
@@ -193,7 +193,7 @@ func undoOnceRandom(blocks int32) error {
 				}
 			}
 			sc.BackOne(adds, durations, delHashes)
-			afterRoot := f.getRoots()
+			afterRoot := f.GetRoots()
 			if !reflect.DeepEqual(beforeRoot, afterRoot) {
 				return fmt.Errorf("undo mismatch")
 			}
@@ -219,7 +219,7 @@ func undoAddDelOnce(numStart, numAdds, numDels uint32) error {
 		return err
 	}
 	fmt.Printf(f.ToString())
-	beforeTops := f.getRoots()
+	beforeTops := f.GetRoots()
 	for i, h := range beforeTops {
 		fmt.Printf("beforeTops %d %x\n", i, h)
 	}
@@ -247,7 +247,7 @@ func undoAddDelOnce(numStart, numAdds, numDels uint32) error {
 	}
 	fmt.Print(f.ToString())
 	fmt.Print(ub.ToString())
-	afterTops := f.getRoots()
+	afterTops := f.GetRoots()
 	for i, h := range afterTops {
 		fmt.Printf("afterTops %d %x\n", i, h)
 	}
@@ -257,7 +257,7 @@ func undoAddDelOnce(numStart, numAdds, numDels uint32) error {
 		return err
 	}
 
-	undoneTops := f.getRoots()
+	undoneTops := f.GetRoots()
 	for i, h := range undoneTops {
 		fmt.Printf("undoneTops %d %x\n", i, h)
 	}


### PR DESCRIPTION
Function getroots is exported so that bridge nodes are able to query
the accumulator roots.