### PR TITLE
accumulator/forestproofs: Fix bug in ProveBatch()

### DIFF
--- a/accumulator/forestproofs.go
+++ b/accumulator/forestproofs.go
@@ -142,7 +142,9 @@ func (f *Forest) ProveBatch(hs []Hash) (BatchProof, error) {
 	if len(hs) == 0 {
 		return bp, nil
 	}
-	if f.data.size() < 2 {
+	// When there is only 1 leaf in the entire forest, the leaf is the proof.
+	// When there are no leaves, there's nothing to prove.
+	if f.numLeaves <= 1 {
 		return bp, nil
 	}
 


### PR DESCRIPTION
Previously f.data.size() was used to determine if there is only a single
leaf in the forest. The single leaf check is important as for a forest
with only 1 leaf, the leaf is the proof and a batchproof shouldn't be
generated.

f.data.size() returns allocated size ofthe entire forest, not the logical
size.  This means that if the forest allocates beforehand or reorgs back
to 0 leaves, the size check will fail and ProveBatch() will wrongly
generate proofs.

f.numLeaves always returns the logical number of elements in the forest,
avoiding this bug.