### PR TITLE
accumulator/forestproofs: fix off-by-one error in `Prove` sanity check

### DIFF
--- a/accumulator/forestproofs.go
+++ b/accumulator/forestproofs.go
@@ -25,7 +25,7 @@ func (f *Forest) Prove(wanted Hash) (Proof, error) {
 	}
 
 	// should never happen
-	if pos > f.numLeaves {
+	if pos >= f.numLeaves {
 		return pr, fmt.Errorf("prove: got leaf position %d but only %d leaves exist",
 			pos, f.numLeaves)
 	}


### PR DESCRIPTION
If the number of leaves is `numLeaves`, valid leaf positions are in the range of `(0, numLeaves-1)`, i.e. `pos == numLeaves` is already out of range. Take this into account for the sanity check before calling `detectSubTreeRows`.