### PR TITLE
remove remaining clair references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 cmd/txottl/txottl
 cmd/blockparser/blockparser
 cmd/ibdsim/ibdsim
-cmd/clair/clair
 cmd/simcmd/simcmd
 cmd/utreexoclient/utreexoclient
 cmd/utreexoserver/utreexoserver

--- a/cmd/readme.md
+++ b/cmd/readme.md
@@ -40,8 +40,3 @@ https://github.com/mit-dci/utreexo/blob/master/utreexo.pdf
 ## util
 
 Various reused functions, constants, and paths used in all the packages.
-
-## clair
-
-An attempt at implementing Bélády's clairvoyent algorithm. Currently, it does not build.
-This code is kept to be used in the future.


### PR DESCRIPTION
The clair folder has been removed (commit 4ec5833a0b6064300e69961a2320e7e1edeb44b0), i.e. it doesn't make sense to refer to it anymore.