### PR TITLE
accumulator/forestproofs: remove single-leaf `Prove{Many}`/`Verify{Many}` methods

### DIFF
--- a/accumulator/forest_test.go
+++ b/accumulator/forest_test.go
@@ -195,7 +195,7 @@ func Test2Fwd1Back(t *testing.T) {
 		fmt.Printf(s)
 
 		// get proof for the first
-		_, err = f.Prove(adds[0].Hash)
+		_, err = f.ProveBatch([]Hash{adds[0].Hash})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -210,16 +210,22 @@ func Test2Fwd1Back(t *testing.T) {
 		//		fmt.Printf(s)
 
 		// get proof for the 2nd
-		keep, err := f.Prove(adds[1].Hash)
+		keep, err := f.ProveBatch([]Hash{adds[1].Hash})
 		if err != nil {
 			t.Fatal(err)
 		}
-		// check proof
+		// convert batch proof to single proof
+		// (TODO: remove this as soon as soon as Verify is removed and replaced by VerifyBatchProof)
+		var proof Proof;
+		proof.Position = keep.Targets[0]
+		proof.Payload = adds[1].Hash
+		proof.Siblings = keep.Proof
 
-		worked := f.Verify(keep)
+		// check proof
+		worked := f.Verify(proof)
 		if !worked {
 			t.Fatalf("proof at position %d, length %d failed to verify\n",
-				keep.Position, len(keep.Siblings))
+				proof.Position, len(proof.Siblings))
 		}
 	}
 }

--- a/accumulator/forest_test.go
+++ b/accumulator/forest_test.go
@@ -210,22 +210,16 @@ func Test2Fwd1Back(t *testing.T) {
 		//		fmt.Printf(s)
 
 		// get proof for the 2nd
-		keep, err := f.ProveBatch([]Hash{adds[1].Hash})
+		proof, err := f.ProveBatch([]Hash{adds[1].Hash})
 		if err != nil {
 			t.Fatal(err)
 		}
-		// convert batch proof to single proof
-		// (TODO: remove this as soon as soon as Verify is removed and replaced by VerifyBatchProof)
-		var proof Proof;
-		proof.Position = keep.Targets[0]
-		proof.Payload = adds[1].Hash
-		proof.Siblings = keep.Proof
 
 		// check proof
-		worked := f.Verify(proof)
-		if !worked {
+		err = f.VerifyBatchProof([]Hash{adds[1].Hash}, proof)
+		if err != nil {
 			t.Fatalf("proof at position %d, length %d failed to verify\n",
-				proof.Position, len(proof.Siblings))
+				proof.Targets[0], len(proof.Proof))
 		}
 	}
 }


### PR DESCRIPTION
As suggested by @adiabat in https://github.com/mit-dci/utreexo/pull/352#issuecomment-1101462359:
> We should probably get rid of the Prove function since really we're always going to use batch proofs, even if there's only one leaf.

`Prove` and `Verify` are only used in one unit test, so this one is adapted to use the batch proof equivalents `ProveBatch` and `VerifyBatchProof` instead. Note that this also makes the structure `Proof` obsolete, so this is removed as well.